### PR TITLE
blacklist stores unzipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Here, the changes to `genomepy` will be summarized.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+- Blacklists are automatically unzipped.
 
 ## [0.7.1] - 2019-11-20
 

--- a/genomepy/plugins/blacklist.py
+++ b/genomepy/plugins/blacklist.py
@@ -27,7 +27,7 @@ class BlacklistPlugin(Plugin):
             os.remove(fname)
 
         if not os.path.exists(fname):
-            link = self.http_dict.get(genome.name.split('.')[0])
+            link = self.http_dict.get(genome.name.split(".")[0])
             if link is None:
                 sys.stderr.write("No blacklist found for {}\n".format(genome.name))
                 return
@@ -36,9 +36,7 @@ class BlacklistPlugin(Plugin):
                 response = urlopen(link)
                 with open(fname, "wb") as bed:
                     # unzip the response with some zlib magic
-                    unzipped = zlib.decompress(
-                        response.read(), 16 + zlib.MAX_WBITS
-                    )
+                    unzipped = zlib.decompress(response.read(), 16 + zlib.MAX_WBITS)
                     bed.write(unzipped)
             except Exception as e:
                 sys.stderr.write(e)
@@ -47,7 +45,5 @@ class BlacklistPlugin(Plugin):
                 )
 
     def get_properties(self, genome):
-        props = {
-            "blacklist": re.sub(".fa(.gz)?$", ".blacklist.bed", genome.filename)
-        }
+        props = {"blacklist": re.sub(".fa(.gz)?$", ".blacklist.bed", genome.filename)}
         return props

--- a/genomepy/plugins/blacklist.py
+++ b/genomepy/plugins/blacklist.py
@@ -1,7 +1,10 @@
 import os.path
 import re
 import sys
+import zlib
+
 from urllib.request import urlopen
+
 from genomepy.plugin import Plugin
 
 
@@ -32,7 +35,11 @@ class BlacklistPlugin(Plugin):
                 sys.stderr.write("Downloading blacklist {}\n".format(link))
                 response = urlopen(link)
                 with open(fname, "wb") as bed:
-                    bed.write(response.read())
+                    # unzip the response with some zlib magic
+                    unzipped = zlib.decompress(
+                        response.read(), 16 + zlib.MAX_WBITS
+                    ).decode("utf-8")
+                    bed.write(unzipped)
             except Exception as e:
                 sys.stderr.write(e)
                 sys.stderr.write(
@@ -41,6 +48,6 @@ class BlacklistPlugin(Plugin):
 
     def get_properties(self, genome):
         props = {
-            "blacklist": re.sub(".fa(.gz)?$", ".blacklist.bed.gz", genome.filename)
+            "blacklist": re.sub(".fa(.gz)?$", ".blacklist.bed", genome.filename)
         }
         return props

--- a/genomepy/plugins/blacklist.py
+++ b/genomepy/plugins/blacklist.py
@@ -27,7 +27,7 @@ class BlacklistPlugin(Plugin):
             os.remove(fname)
 
         if not os.path.exists(fname):
-            link = self.http_dict.get(genome.name)
+            link = self.http_dict.get(genome.name.split('.')[0])
             if link is None:
                 sys.stderr.write("No blacklist found for {}\n".format(genome.name))
                 return
@@ -38,7 +38,7 @@ class BlacklistPlugin(Plugin):
                     # unzip the response with some zlib magic
                     unzipped = zlib.decompress(
                         response.read(), 16 + zlib.MAX_WBITS
-                    ).decode("utf-8")
+                    )
                     bed.write(unzipped)
             except Exception as e:
                 sys.stderr.write(e)

--- a/tests/test_8_plugins.py
+++ b/tests/test_8_plugins.py
@@ -81,7 +81,7 @@ def test_blacklist(genome, force):
     p = BlacklistPlugin()
 
     p.after_genome_download(genome, force=force)
-    fname = re.sub(".fa(.gz)?$", ".blacklist.bed.gz", genome.filename)
+    fname = re.sub(".fa(.gz)?$", ".blacklist.bed", genome.filename)
     assert os.path.exists(fname)
 
     force_test(p, fname, genome, force)


### PR DESCRIPTION
Blacklists are now immediately unzipped, I tried on mm10 assembly and it seemed to work:
```
chr10   3110060 3110270
chr10   22142530        22142880
chr10   22142830        22143070
chr10   58223870        58224100
```
I think I found a pre-existing bug that blacklists are actually never found since they are searched for with the [assembly].fa name, but the dictionary for the urls is without the .fa. 
```
(genomepy) sande@ocimum:~/Desktop$ genomepy install mm10 UCSC -g .
downloading from http://hgdownload.soe.ucsc.edu/goldenPath/mm10/bigZips/chromFa.tar.gz...
done...
name: mm10
local name: mm10
fasta: ./mm10/mm10.fa
No blacklist found for mm10.fa
Downloading blacklist None
'NoneType' object has no attribute 'timeout'
Could not download blacklist file from None
```
I fixed it with splitting on dots and taking the first item as filename, and now it seems to work.