### PR TITLE
fix #63 hg19 blacklist url

### DIFF
--- a/genomepy/plugins/blacklist.py
+++ b/genomepy/plugins/blacklist.py
@@ -14,7 +14,8 @@ class BlacklistPlugin(Plugin):
         "ce10": base_url + "ce10-C.elegans/ce10-blacklist.bed.gz",
         "dm3": base_url + "dm3-D.melanogaster/dm3-blacklist.bed.gz",
         "hg38": base_url + "hg38-human/hg38.blacklist.bed.gz",
-        "hg19": base_url + "hg19-human/wgEncodeHg19ConsensusSignalArtifactRegions.bed.gz",
+        "hg19": base_url
+        + "hg19-human/wgEncodeHg19ConsensusSignalArtifactRegions.bed.gz",
         "mm9": base_url + "mm9-mouse/mm9-blacklist.bed.gz",
         "mm10": base_url + "mm10-mouse/mm10.blacklist.bed.gz",
     }

--- a/genomepy/plugins/blacklist.py
+++ b/genomepy/plugins/blacklist.py
@@ -14,7 +14,7 @@ class BlacklistPlugin(Plugin):
         "ce10": base_url + "ce10-C.elegans/ce10-blacklist.bed.gz",
         "dm3": base_url + "dm3-D.melanogaster/dm3-blacklist.bed.gz",
         "hg38": base_url + "hg38-human/hg38.blacklist.bed.gz",
-        "hg19": base_url + "hg19-human/hg19.blacklist.bed.gz",
+        "hg19": base_url + "hg19-human/wgEncodeHg19ConsensusSignalArtifactRegions.bed.gz",
         "mm9": base_url + "mm9-mouse/mm9-blacklist.bed.gz",
         "mm10": base_url + "mm10-mouse/mm10.blacklist.bed.gz",
     }


### PR DESCRIPTION
Multiple blacklists were made for hg19. Selected the consensus blacklist.
Note that all of the hg19 blacklists are in a BED (4+2) format, while other blacklists are BED3.

fixes #63 