### PR TITLE
split genome_dir and genomes_dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,7 +145,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Fixed genome_dir argument to `genomepy install`
+- Fixed genomes_dir argument to `genomepy install`
 - Fixed msgpack dependency
 - Fixed issue with `config generate` where config directory does note exist.
 

--- a/README.md
+++ b/README.md
@@ -135,13 +135,13 @@ To set the default genome directory to `/data/genomes` for instance,
 edit `~/.config/genomepy/genomepy.yaml` and change the following line:
 
 ```
-genome_dir: ~/.local/share/genomes/
+genomes_dir: ~/.local/share/genomes/
 ```
 
 to:
 
 ```
-genome_dir: /data/genomes
+genomes_dir: /data/genomes
 ```
 
 The genome directory can also be explicitly specified in both the Python API as well as on the command-line.
@@ -383,7 +383,7 @@ To show the contents of the config file:
 ```
 $ genomepy config show
 # Directory were downloaded genomes will be stored
-genome_dir: ~/.local/share/genomes/
+genomes_dir: ~/.local/share/genomes/
 
 plugin:
  - blacklist
@@ -424,12 +424,12 @@ NCBI	GRCh38.p7	Homo sapiens; Genome Reference Consortium
 NCBI	GRCh38.p8	Homo sapiens; Genome Reference Consortium
 NCBI	GRCh38.p9	Homo sapiens; Genome Reference Consortium
 Ensembl	GRCh38.p10	Human
->>> genomepy.install_genome("hg38", "UCSC", genome_dir="/data/genomes")
+>>> genomepy.install_genome("hg38", "UCSC", genomes_dir="/data/genomes")
 downloading...
 done...
 name: hg38
 fasta: /data/genomes/hg38/hg38.fa
->>> g = genomepy.Genome("hg38", genome_dir="/data/genomes")
+>>> g = genomepy.Genome("hg38", genomes_dir="/data/genomes")
 >>> g["chr6"][166502000:166503000]
 tgtatggtccctagaggggccagagtcacagagatggaaagtggatggcgggtgccgggggctggggagctactgtgcagggggacagagctttagttctgcaagatgaaacagttctggagatggacggtggggatgggggcccagcaatgggaacgtgcttaatgccactgaactgggcacttaaacgtggtgaaaactgtaaaagtcatgtgtatttttctacaattaaaaaaaATCTGCCACAGAGTTAAAAAAATAACCACTATTTTCTGGAAATGGGAAGGAAAAGTTACAGCATGTAATTAAGATGACAATTTATAATGAACAAGGCAAATCTTTTCATCTTTGCCTTTTGGGCATATTCAATCTTTGCCCAGAATTAAGCACCTTTCAAGATTAATTCTCTAATAATTCTAGTTGAACAACACAACCTTTTCCTTCAAGCTTGCAATTAAATAAGGCTATTTTTAGCTGTAAGGATCACGCTGACCTTCAGGAGCAATGAGAACCGGCACTCCCGGCCTGAGTGGATGCACGGGGAGTGTGTCTAACACACAGGCGTCAACAGCCAGGGCCGCACGAGGAGGAGGAGTGGCAACGTCCACACAGACTCACAACACGGCACTCCGACTTGGAGGGTAATTAATACCAGGTTAACTTCTGGGATGACCTTGGCAACGACCCAAGGTGACAGGCCAGGCTCTGCAATCACCTCCCAATTAAGGAGAGGCGAAAGGGGACTCCCAGGGCTCAGAGCACCACGGGGTTCTAGGTCAGACCCACTTTGAAATGGAAATCTGGCCTTGTGCTGCTGCTCTTGTGGGGAGACAGCAGCTGCGGAGGCTGCTCTCTTCATGGGATTACTCTGGATAAAGTCTTTTTTGATTCTACgttgagcatcccttatctgaaatgcctgaaaccggaagtgtttaggatttggggattttgcaatatttacttatatataatgagatatcttggagatgggccacaa
 ```

--- a/genomepy/cfg/default.yaml
+++ b/genomepy/cfg/default.yaml
@@ -1,3 +1,3 @@
 bgzip: false
-genome_dir: ~/.local/share/genomes/
+genomes_dir: ~/.local/share/genomes/
 plugin: []

--- a/genomepy/cli.py
+++ b/genomepy/cli.py
@@ -48,10 +48,10 @@ def genomes(provider=None):
 
 # extended options for genomepy install
 general_install_options = {
-    "genome_dir": {
+    "genomes_dir": {
         "short": "g",
-        "long": "genome_dir",
-        "help": "genome directory",
+        "long": "genomes_dir",
+        "help": "genomes directory",
         "default": None,
     },
     "localname": {
@@ -178,7 +178,7 @@ def custom_options(options):
 def install(
     name,
     provider,
-    genome_dir,
+    genomes_dir,
     localname,
     mask,
     regex,
@@ -195,7 +195,7 @@ def install(
     genomepy.install_genome(
         name,
         provider,
-        genome_dir=genome_dir,
+        genomes_dir=genomes_dir,
         localname=localname,
         mask=mask,
         regex=regex,

--- a/genomepy/functions.py
+++ b/genomepy/functions.py
@@ -13,7 +13,7 @@ from genomepy.utils import (
     generate_fa_sizes,
     get_localname,
     sanitize_annotation,
-    get_genome_dir,
+    get_genomes_dir,
     glob_ext_files,
     mkdir_p,
 )
@@ -89,23 +89,25 @@ def _is_genome_dir(dirname):
     return len(glob(f"{dirname}/*.fa")) > 0
 
 
-def list_installed_genomes(genome_dir=None):
+def list_installed_genomes(genomes_dir=None):
     """
     List all available genomes.
 
     Parameters
     ----------
-    genome_dir : str
+    genomes_dir : str
         Directory with installed genomes.
 
     Returns
     -------
     list with genome names
     """
-    genome_dir = get_genome_dir(genome_dir)
+    genomes_dir = get_genomes_dir(genomes_dir)
 
     return [
-        f for f in os.listdir(genome_dir) if _is_genome_dir(os.path.join(genome_dir, f))
+        f
+        for f in os.listdir(genomes_dir)
+        if _is_genome_dir(os.path.join(genomes_dir, f))
     ]
 
 
@@ -152,7 +154,7 @@ def generate_env(fname=None):
 def install_genome(
     name,
     provider,
-    genome_dir=None,
+    genomes_dir=None,
     localname=None,
     mask="soft",
     regex=None,
@@ -176,7 +178,7 @@ def install_genome(
     provider : str
         Provider name
 
-    genome_dir : str , optional
+    genomes_dir : str , optional
         Where to store the fasta files
 
     localname : str , optional
@@ -223,9 +225,9 @@ def install_genome(
             URL only: direct link to annotation file.
             Required if this is not the same directory as the fasta.
     """
-    genome_dir = get_genome_dir(genome_dir, check_exist=False)
+    genomes_dir = get_genomes_dir(genomes_dir, check_exist=False)
     localname = get_localname(name, localname)
-    out_dir = os.path.join(genome_dir, localname)
+    out_dir = os.path.join(genomes_dir, localname)
 
     # Check if genome already exists, or if downloading is forced
     genome_found = (
@@ -236,7 +238,7 @@ def install_genome(
         p = ProviderBase.create(provider)
         p.download_genome(
             name,
-            genome_dir,
+            genomes_dir,
             mask=mask,
             regex=regex,
             invert_match=invert_match,
@@ -251,7 +253,7 @@ def install_genome(
 
     # Generates a Fasta object and the index file
     if genome_found:
-        g = Genome(localname, genome_dir=genome_dir)
+        g = Genome(localname, genomes_dir=genomes_dir)
 
     # Generate sizes file (if not found or if generation is forced)
     sizes_file = os.path.join(out_dir, localname + ".fa.sizes")
@@ -270,7 +272,7 @@ def install_genome(
     if (not annotation_found or force) and annotation:
         # Download annotation from provider
         p = ProviderBase.create(provider)
-        p.download_annotation(name, genome_dir, localname=localname, **kwargs)
+        p.download_annotation(name, genomes_dir, localname=localname, **kwargs)
 
         # Sanitize annotation if needed (requires genome)
         annotation_found = len(glob_ext_files(out_dir, "gtf")) >= 1

--- a/genomepy/genome.py
+++ b/genomepy/genome.py
@@ -65,12 +65,7 @@ class Genome(Fasta):
         if os.path.isfile(path_name):
             return path_name
 
-        if os.path.isdir(path_name):
-            for f in glob_ext_files(path_name):
-                if self.name + ".fa" in os.path.basename(f):
-                    return f
-
-        for f in glob_ext_files(self.genome_dir):
+        for f in glob_ext_files(path_name) + glob_ext_files(self.genome_dir):
             if self.name + ".fa" in os.path.basename(f):
                 return f
 

--- a/genomepy/genome.py
+++ b/genomepy/genome.py
@@ -11,7 +11,7 @@ from genomepy.provider import ProviderBase
 from genomepy.utils import (
     read_readme,
     write_readme,
-    get_genome_dir,
+    get_genomes_dir,
     get_localname,
     glob_ext_files,
     generate_gap_bed,
@@ -30,7 +30,7 @@ class Genome(Fasta):
     name : str
         Genome name
 
-    genome_dir : str
+    genomes_dir : str
         Genome installation directory
 
     Returns
@@ -38,9 +38,11 @@ class Genome(Fasta):
     pyfaidx.Fasta object
     """
 
-    def __init__(self, name, genome_dir=None):
-        self.genome_dir = get_genome_dir(genome_dir)
-        self.name, self.filename = self._get_name_and_filename(name)
+    def __init__(self, name, genomes_dir=None):
+        self.name = os.path.basename(re.sub(".fa(.gz)?$", "", get_localname(name)))
+        self.genomes_dir = get_genomes_dir(genomes_dir)
+        self.genome_dir = os.path.join(self.genomes_dir, self.name)
+        self.filename = self._get_filename(name)
         super(Genome, self).__init__(self.filename)
 
         metadata = self._read_metadata()
@@ -52,49 +54,35 @@ class Genome(Fasta):
         for plugin in get_active_plugins():
             self.props[plugin.name()] = plugin.get_properties(self)
 
-    def _get_name_and_filename(self, name):
+    def _get_filename(self, name):
         """
-        name can be just a name (e.g. hg38) or an abspath to a fasta file or the fasta's folder
+        accepts path to a fasta file, path to a fasta folder, or
+        the name of a genome (e.g. hg38).
 
-        returns the name and the abspath to the (closest) fasta file
+        returns the abspath to the fasta file
         """
-        stripped_name = get_localname(name)
-        stripped_name = re.sub(".fa(.gz)?$", "", stripped_name)
+        path_name = os.path.abspath(os.path.expanduser(name))
+        if os.path.isfile(path_name):
+            return path_name
 
-        if os.path.isfile(name):
-            filename = name
-            name = os.path.basename(stripped_name)
-        elif os.path.isdir(name) and glob_ext_files(name)[0].startswith(
-            os.path.basename(name) + ".fa"
-        ):
-            filename = glob_ext_files(name)[0]
-            name = os.path.basename(stripped_name)
-        else:
-            fasta_dir = os.path.join(self.genome_dir, stripped_name)
-            filenames = glob_ext_files(fasta_dir)
-            if len(filenames) == 1:
-                filename = filenames[0]
-            elif len(filenames) == 0:
-                raise FileNotFoundError(
-                    f"no *.fa files found in genome_dir {fasta_dir}"
-                )
-            else:
-                filename = os.path.join(fasta_dir, stripped_name + ".fa")
-                if filename not in filenames:
-                    filename += ".gz"
-                if filename not in filenames:
-                    raise Exception(
-                        f"Multiple fasta files found, but not {stripped_name}.fa!"
-                    )
-            name = stripped_name
+        if os.path.isdir(path_name):
+            for f in glob_ext_files(path_name):
+                if self.name + ".fa" in os.path.basename(f):
+                    return f
 
-        return [name, filename]
+        for f in glob_ext_files(self.genome_dir):
+            if self.name + ".fa" in os.path.basename(f):
+                return f
+
+        raise FileNotFoundError(
+            f"could not find {self.name}.fa(.gz) in genome_dir {self.genome_dir}"
+        )
 
     def _read_metadata(self):
         """
         Read genome metadata from genome README.txt (if it exists).
         """
-        readme = os.path.join(self.genome_dir, self.name, "README.txt")
+        readme = os.path.join(self.genome_dir, "README.txt")
         metadata, lines = read_readme(readme)
 
         update_metadata = False

--- a/genomepy/provider.py
+++ b/genomepy/provider.py
@@ -183,7 +183,7 @@ class ProviderBase(object):
     def download_genome(
         self,
         name,
-        genome_dir,
+        genomes_dir,
         localname=None,
         mask="soft",
         regex=None,
@@ -199,7 +199,7 @@ class ProviderBase(object):
         name : str
             Genome / species name
 
-        genome_dir : str
+        genomes_dir : str
             Directory to install genome
 
         localname : str , optional
@@ -226,8 +226,8 @@ class ProviderBase(object):
         name = safe(name)
         localname = get_localname(name, localname)
 
-        genome_dir = os.path.expanduser(genome_dir)
-        out_dir = os.path.join(genome_dir, localname)
+        genomes_dir = os.path.expanduser(genomes_dir)
+        out_dir = os.path.join(genomes_dir, localname)
         if not os.path.exists(out_dir):
             mkdir_p(out_dir)
 
@@ -287,7 +287,7 @@ class ProviderBase(object):
 
             # transfer the genome from the tmpdir to the genome_dir
             src = fname
-            dst = os.path.join(genome_dir, localname, os.path.basename(fname))
+            dst = os.path.join(genomes_dir, localname, os.path.basename(fname))
             shutil.move(src, dst)
 
         sys.stderr.write("\n")
@@ -296,7 +296,7 @@ class ProviderBase(object):
         sys.stderr.write("fasta: {}\n".format(dst))
 
         # Create readme with information
-        readme = os.path.join(genome_dir, localname, "README.txt")
+        readme = os.path.join(genomes_dir, localname, "README.txt")
         metadata = {
             "name": localname,
             "provider": self.name,
@@ -323,11 +323,11 @@ class ProviderBase(object):
         raise NotImplementedError()
 
     @staticmethod
-    def download_and_generate_annotation(genome_dir, annot_url, localname):
+    def download_and_generate_annotation(genomes_dir, annot_url, localname):
         """download annotation file, convert to intermediate file and generate output files"""
 
         # create output directory if missing
-        out_dir = os.path.join(genome_dir, localname)
+        out_dir = os.path.join(genomes_dir, localname)
         if not os.path.exists(out_dir):
             mkdir_p(out_dir)
 
@@ -390,7 +390,7 @@ class ProviderBase(object):
                 dst = os.path.join(out_dir, os.path.basename(f))
                 shutil.move(src, dst)
 
-    def attempt_and_report(self, name, localname, link, genome_dir):
+    def attempt_and_report(self, name, localname, link, genomes_dir):
         if not link:
             sys.stderr.write(
                 f"Could not download genome annotation for {name} from {self.name}.\n"
@@ -399,7 +399,7 @@ class ProviderBase(object):
 
         sys.stderr.write(f"\nDownloading annotation from {link}...\n")
         try:
-            self.download_and_generate_annotation(genome_dir, link, localname)
+            self.download_and_generate_annotation(genomes_dir, link, localname)
         except Exception:
             raise GenomeDownloadError(
                 f"\nCould not download annotation for {name} from {self.name}\n"
@@ -411,12 +411,12 @@ class ProviderBase(object):
         sys.stderr.write(f"Annotation download successful\n")
 
         # Update readme annotation URL, or make a new
-        readme = os.path.join(genome_dir, localname, "README.txt")
+        readme = os.path.join(genomes_dir, localname, "README.txt")
         metadata, lines = read_readme(readme)
         metadata["annotation url"] = link
         write_readme(readme, metadata, lines)
 
-    def download_annotation(self, name, genome_dir, localname=None, **kwargs):
+    def download_annotation(self, name, genomes_dir, localname=None, **kwargs):
         """
         Download annotation file to to a specific directory
 
@@ -425,7 +425,7 @@ class ProviderBase(object):
         name : str
             Genome / species name
 
-        genome_dir : str
+        genomes_dir : str
             Directory to install annotation
 
         localname : str , optional
@@ -435,7 +435,7 @@ class ProviderBase(object):
 
         link = self.get_annotation_download_link(name, **kwargs)
 
-        self.attempt_and_report(name, localname, link, genome_dir)
+        self.attempt_and_report(name, localname, link, genomes_dir)
 
     def _search_taxids(self, genome, term):
         """check if search term corresponds to the provider's taxonomy field(s)"""
@@ -1180,7 +1180,7 @@ class UrlProvider(ProviderBase):
         if check_url(link):
             return link
 
-    def download_annotation(self, url, genome_dir, localname=None, **kwargs):
+    def download_annotation(self, url, genomes_dir, localname=None, **kwargs):
         """
         Attempts to download a gtf or gff3 file from the same location as the genome url
 
@@ -1189,7 +1189,7 @@ class UrlProvider(ProviderBase):
         url : str
             url of where to download genome from
 
-        genome_dir : str
+        genomes_dir : str
             Directory to install annotation
 
         localname : str , optional
@@ -1209,4 +1209,4 @@ class UrlProvider(ProviderBase):
         else:
             link = self.search_url_for_annotation(url)
 
-        self.attempt_and_report(name, localname, link, genome_dir)
+        self.attempt_and_report(name, localname, link, genomes_dir)

--- a/genomepy/utils.py
+++ b/genomepy/utils.py
@@ -224,18 +224,18 @@ def glob_ext_files(dirname, ext="fa"):
     ]
 
 
-def get_genome_dir(genome_dir=None, check_exist=True):
-    """import genome_dir if none is given, and check validity"""
-    if not genome_dir:
-        genome_dir = config.get("genome_dir", None)
-    if not genome_dir:
-        raise norns.exceptions.ConfigError("Please provide or configure a genome_dir")
+def get_genomes_dir(genomes_dir=None, check_exist=True):
+    """import genomes_dir if none is given, and check validity"""
+    if not genomes_dir:
+        genomes_dir = config.get("genomes_dir", None)
+    if not genomes_dir:
+        raise norns.exceptions.ConfigError("Please provide or configure a genomes_dir")
 
-    genome_dir = os.path.expanduser(genome_dir)
-    if not os.path.exists(genome_dir) and check_exist:
-        raise FileNotFoundError(f"Genome_dir {genome_dir} does not exist!")
+    genomes_dir = os.path.abspath(os.path.expanduser(genomes_dir))
+    if not os.path.exists(genomes_dir) and check_exist:
+        raise FileNotFoundError(f"Genomes_dir {genomes_dir} does not exist!")
 
-    return genome_dir
+    return genomes_dir
 
 
 def safe(name):

--- a/tests/02_utils_test.py
+++ b/tests/02_utils_test.py
@@ -124,14 +124,14 @@ def test_glob_ext_files(file="tests/data/small_genome.fa"):
     assert len(genomepy.utils.glob_ext_files("tests/data", "fake_ext")) == 0
 
 
-def test_get_genome_dir(genome_dir="tests/data"):
+def test_get_genomes_dir(genomes_dir="tests/data"):
     # dir does exist
-    gd = genomepy.utils.get_genome_dir(genome_dir=genome_dir, check_exist=True)
-    assert os.path.abspath(gd) == os.path.abspath(genome_dir)
+    gd = genomepy.utils.get_genomes_dir(genomes_dir=genomes_dir, check_exist=True)
+    assert os.path.abspath(gd) == os.path.abspath(genomes_dir)
 
     # dir does not exist
     with pytest.raises(FileNotFoundError):
-        genomepy.utils.get_genome_dir(genome_dir="fake_dir", check_exist=True)
+        genomepy.utils.get_genomes_dir(genomes_dir="fake_dir", check_exist=True)
 
 
 def test_safe(unsafe_name="a name", safe_name="a_name"):

--- a/tests/04_genome_test.py
+++ b/tests/04_genome_test.py
@@ -16,8 +16,8 @@ def test_genome__init__(genome="tests/data/small_genome.fa.gz"):
     with pytest.raises(FileNotFoundError):
         genomepy.Genome("unknown", "unknown")
 
-    # create genome_dir (normally done by downloading the genome)
-    gd = genomepy.utils.get_genome_dir(check_exist=False)
+    # create genomes_dir (normally done by downloading the genome)
+    gd = genomepy.utils.get_genomes_dir(check_exist=False)
     genomepy.utils.mkdir_p(os.path.join(gd, "small_genome"))
 
     # initialize the class (creates the index file)
@@ -32,7 +32,7 @@ def test_genome__init__(genome="tests/data/small_genome.fa.gz"):
 def test__read_metadata(capsys, genome="tests/data/small_genome.fa.gz"):
     # create blank README.txt
     g = genomepy.Genome(genome)
-    readme = os.path.join(g.genome_dir, g.name, "README.txt")
+    readme = os.path.join(g.genomes_dir, g.name, "README.txt")
     if os.path.exists(readme):
         os.unlink(readme)
     metadata, lines = genomepy.utils.read_readme(readme)

--- a/tests/05_provider_test.py
+++ b/tests/05_provider_test.py
@@ -124,7 +124,7 @@ def test_download_genome(
     with TemporaryDirectory(dir=out_dir) as tmpdir:
         p.download_genome(
             name,
-            genome_dir=tmpdir,
+            genomes_dir=tmpdir,
             localname=localname,
             mask=mask,
             regex=regex,
@@ -159,7 +159,7 @@ def test_download_and_generate_annotation(p):
     annot_url = "https://www.google.com"
     with pytest.raises(TypeError), TemporaryDirectory(dir=out_dir) as tmpdir:
         p.download_and_generate_annotation(
-            genome_dir=tmpdir, annot_url=annot_url, localname=localname
+            genomes_dir=tmpdir, annot_url=annot_url, localname=localname
         )
 
     annot_url = (
@@ -168,7 +168,7 @@ def test_download_and_generate_annotation(p):
     )
     with TemporaryDirectory(dir=out_dir) as tmpdir:
         p.download_and_generate_annotation(
-            genome_dir=tmpdir, annot_url=annot_url, localname=localname
+            genomes_dir=tmpdir, annot_url=annot_url, localname=localname
         )
 
         fname = os.path.join(tmpdir, localname, localname + ".annotation.gtf.gz")
@@ -209,7 +209,7 @@ def test_download_annotation(p):
         "http://hgdownload.cse.ucsc.edu/goldenPath/sacCer3/database/ensGene.txt.gz"
     )
     with TemporaryDirectory(dir=out_dir) as tmpdir:
-        p.download_annotation(name=name, genome_dir=tmpdir, localname=localname)
+        p.download_annotation(name=name, genomes_dir=tmpdir, localname=localname)
 
         # check download_and_generate_annotation output
         fname = os.path.join(tmpdir, localname, localname + ".annotation.gtf.gz")

--- a/tests/09_provider_url_test.py
+++ b/tests/09_provider_url_test.py
@@ -107,7 +107,7 @@ def test_download_annotation(p):
     with TemporaryDirectory(dir=out_dir) as tmpdir:
         p.download_annotation(
             url="string",
-            genome_dir=tmpdir,
+            genomes_dir=tmpdir,
             localname=localname,
             **{"to_annotation": annot_url},
         )

--- a/tests/10_functions_test.py
+++ b/tests/10_functions_test.py
@@ -91,12 +91,12 @@ def test_list_installed_genomes():
 
 @pytest.mark.skipif(not travis or not linux, reason="slow")
 def test_install_genome():
-    out_dir = genomepy.functions.get_genome_dir(None, False)
+    out_dir = genomepy.functions.get_genomes_dir(None, False)
     localname = "my_genome"
     genomepy.functions.install_genome(
         name="fr3",
         provider="UCSC",
-        genome_dir=None,
+        genomes_dir=None,
         localname=localname,
         annotation=True,
         force=True,

--- a/tests/11_plugins_test.py
+++ b/tests/11_plugins_test.py
@@ -35,18 +35,19 @@ def genome(request):
     name = "ce10"  # Use fake name for blacklist test
     fafile = "tests/data/small_genome.fa.gz"
 
-    genome_dir = os.path.join(os.getcwd(), ".genomepy_plugin_tests")
-    if os.path.exists(genome_dir):
-        shutil.rmtree(genome_dir)
-    genomepy.utils.mkdir_p(os.path.join(genome_dir, name))
-    fname = os.path.join(genome_dir, name, f"{name}.fa.gz")
+    genomes_dir = os.path.join(os.getcwd(), ".genomepy_plugin_tests")
+    if os.path.exists(genomes_dir):
+        shutil.rmtree(genomes_dir)
+    genome_dir = os.path.join(genomes_dir, name)
+    genomepy.utils.mkdir_p(genome_dir)
+    fname = os.path.join(genome_dir, f"{name}.fa.gz")
     shutil.copyfile(fafile, fname)
 
     # unzip genome if required
     if request.param == "unzipped":
         sp.check_call(["gunzip", fname])
 
-    return genomepy.Genome(name, genome_dir=genome_dir)
+    return genomepy.Genome(name, genomes_dir=genomes_dir)
 
 
 def test_blacklist(genome):

--- a/tests/e02_install_options_test.py
+++ b/tests/e02_install_options_test.py
@@ -59,7 +59,7 @@ if not skip:
         genomepy.install_genome(
             genome,
             provider,
-            genome_dir=tmp,
+            genomes_dir=tmp,
             localname=localname,
             bgzip=bgzip,
             force=force,
@@ -77,7 +77,7 @@ if not skip:
         genomepy.install_genome(
             genome,
             provider,
-            genome_dir=tmp,
+            genomes_dir=tmp,
             localname=localname,
             bgzip=bgzip,
             force=force,
@@ -105,7 +105,7 @@ if not skip:
         genomepy.install_genome(
             genome,
             provider,
-            genome_dir=tmp,
+            genomes_dir=tmp,
             localname=localname,
             annotation=annotation,
             skip_sanitizing=True,
@@ -126,7 +126,7 @@ if not skip:
         genomepy.install_genome(
             genome,
             provider,
-            genome_dir=tmp,
+            genomes_dir=tmp,
             localname=localname,
             annotation=annotation,
             force=force,

--- a/tests/e03_human_genomes_test.py
+++ b/tests/e03_human_genomes_test.py
@@ -18,8 +18,8 @@ if not skip:
         specific sequence.
         """
         tmp = mkdtemp()
-        genomepy.install_genome("hg38", "UCSC", genome_dir=tmp)
-        g = genomepy.Genome("hg38", genome_dir=tmp)
+        genomepy.install_genome("hg38", "UCSC", genomes_dir=tmp)
+        g = genomepy.Genome("hg38", genomes_dir=tmp)
         seq = g["chr6"][166168664:166168679]
         assert str(seq) == "CCTCCTCGCTCTCTT"
         shutil.rmtree(tmp)
@@ -32,8 +32,8 @@ if not skip:
         specific sequence.
         """
         tmp = mkdtemp()
-        genomepy.install_genome("GRCh38.p13", "Ensembl", genome_dir=tmp)
-        g = genomepy.Genome("GRCh38.p13", genome_dir=tmp)
+        genomepy.install_genome("GRCh38.p13", "Ensembl", genomes_dir=tmp)
+        g = genomepy.Genome("GRCh38.p13", genomes_dir=tmp)
         seq = g["6"][166168664:166168679]
         assert str(seq) == "CCTCCTCGCTCTCTT"
         shutil.rmtree(tmp)
@@ -46,8 +46,8 @@ if not skip:
         specific sequence.
         """
         tmp = mkdtemp()
-        genomepy.install_genome("GRCh38.p13", "NCBI", genome_dir=tmp)
-        g = genomepy.Genome("GRCh38.p13", genome_dir=tmp)
+        genomepy.install_genome("GRCh38.p13", "NCBI", genomes_dir=tmp)
+        g = genomepy.Genome("GRCh38.p13", genomes_dir=tmp)
         seq = g["6"][166168664:166168679]
         assert str(seq) == "CCTCCTCGCTCTCTT"
         shutil.rmtree(tmp)


### PR DESCRIPTION
We we using the variable `genome_dir` to describe the directory which will contain a fasta, as well as the directory which will contains all fasta directories.

In this PR the variable `genome_dir` is split into `genomes_dir` and `genome_dir`.