### PR TITLE
edge case: renamed genome dirs

### DIFF
--- a/genomepy/functions.py
+++ b/genomepy/functions.py
@@ -122,7 +122,7 @@ def generate_exports():
             g = Genome(name)
             env_name = re.sub(r"[^\w]+", "_", name).upper()
             env.append(f"export {env_name}={g.filename}")
-        except FastaIndexingError:
+        except (FastaIndexingError, FileNotFoundError):
             pass
     return env
 


### PR DESCRIPTION
no longer causes an error if the genome file in these dirs doesn't have the exact same name