### PR TITLE
added rm -rf function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `genomepy clean` wont complain when there is nothing to clean
+
 ## [0.9.0] - 2020-09-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,6 +225,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `-r` and `--match/--no-match` option to select sequences by regex.
 
 [Unreleased]: https://github.com/vanheeringen-lab/genomepy/compare/master...develop
+[0.9.0]: https://github.com/vanheeringen-lab/genomepy/compare/0.8.4...0.9.0
 [0.8.4]: https://github.com/vanheeringen-lab/genomepy/compare/0.8.3...0.8.4
 [0.8.3]: https://github.com/vanheeringen-lab/genomepy/compare/0.8.2...0.8.3
 [0.8.2]: https://github.com/vanheeringen-lab/genomepy/compare/0.8.1...0.8.2

--- a/genomepy/functions.py
+++ b/genomepy/functions.py
@@ -14,12 +14,12 @@ from genomepy.utils import (
     get_genomes_dir,
     glob_ext_files,
     mkdir_p,
+    rm_rf,
     read_readme,
     sanitize_annotation,
     safe,
 )
 from pyfaidx import FastaIndexingError
-from shutil import rmtree
 
 config = norns.config("genomepy", default="cfg/default.yaml")
 
@@ -27,8 +27,9 @@ config = norns.config("genomepy", default="cfg/default.yaml")
 def clean():
     """Remove cached data on providers"""
     my_cache_dir = os.path.join(user_cache_dir("genomepy"), __version__)
-    rmtree(my_cache_dir)
+    rm_rf(my_cache_dir)
     mkdir_p(my_cache_dir)
+    print("All clean!")
 
 
 def manage_config(cmd):

--- a/genomepy/plugins/bowtie2.py
+++ b/genomepy/plugins/bowtie2.py
@@ -1,7 +1,6 @@
 import os
-from shutil import rmtree
 from genomepy.plugin import Plugin
-from genomepy.utils import mkdir_p, cmd_ok, run_index_cmd
+from genomepy.utils import mkdir_p, rm_rf, cmd_ok, run_index_cmd
 
 
 class Bowtie2Plugin(Plugin):
@@ -14,7 +13,7 @@ class Bowtie2Plugin(Plugin):
         index_name = genome.plugin["bowtie2"]["index_name"]
         if force:
             # Start from scratch
-            rmtree(index_dir, ignore_errors=True)
+            rm_rf(index_dir)
         mkdir_p(index_dir)
 
         if not any(fname.endswith(".bt2") for fname in os.listdir(index_dir)):

--- a/genomepy/plugins/bwa.py
+++ b/genomepy/plugins/bwa.py
@@ -1,7 +1,6 @@
 import os
-from shutil import rmtree
 from genomepy.plugin import Plugin
-from genomepy.utils import mkdir_p, cmd_ok, run_index_cmd
+from genomepy.utils import mkdir_p, rm_rf, cmd_ok, run_index_cmd
 
 
 class BwaPlugin(Plugin):
@@ -14,7 +13,7 @@ class BwaPlugin(Plugin):
         index_name = genome.plugin["bwa"]["index_name"]
         if force:
             # Start from scratch
-            rmtree(index_dir, ignore_errors=True)
+            rm_rf(index_dir)
         mkdir_p(index_dir)
 
         if not any(fname.endswith(".bwt") for fname in os.listdir(index_dir)):

--- a/genomepy/plugins/gmap.py
+++ b/genomepy/plugins/gmap.py
@@ -1,8 +1,8 @@
 import os.path
-from shutil import move, rmtree
+from shutil import move
 from tempfile import TemporaryDirectory
 from genomepy.plugin import Plugin
-from genomepy.utils import cmd_ok, run_index_cmd, gunzip_and_name, bgzip_and_name
+from genomepy.utils import cmd_ok, rm_rf, run_index_cmd, gunzip_and_name, bgzip_and_name
 
 
 class GmapPlugin(Plugin):
@@ -14,7 +14,7 @@ class GmapPlugin(Plugin):
         index_dir = genome.plugin["gmap"]["index_dir"]
         if force:
             # Start from scratch
-            rmtree(index_dir, ignore_errors=True)
+            rm_rf(index_dir)
 
         if not os.path.exists(index_dir):
             # unzip genome if zipped and return up-to-date genome name

--- a/genomepy/plugins/hisat2.py
+++ b/genomepy/plugins/hisat2.py
@@ -1,9 +1,9 @@
 import os
 import subprocess as sp
-from shutil import rmtree
 from genomepy.plugin import Plugin
 from genomepy.utils import (
     mkdir_p,
+    rm_rf,
     cmd_ok,
     run_index_cmd,
     bgzip_and_name,
@@ -21,7 +21,7 @@ class Hisat2Plugin(Plugin):
             return
 
         index_dir = genome.plugin["hisat2"]["index_dir"]
-        rmtree(index_dir, ignore_errors=True)
+        rm_rf(index_dir)
         mkdir_p(index_dir)
 
         # gunzip genome if bgzipped and return up-to-date genome name

--- a/genomepy/plugins/minimap2.py
+++ b/genomepy/plugins/minimap2.py
@@ -1,7 +1,6 @@
 import os
-from shutil import rmtree
 from genomepy.plugin import Plugin
-from genomepy.utils import mkdir_p, cmd_ok, run_index_cmd
+from genomepy.utils import mkdir_p, rm_rf, cmd_ok, run_index_cmd
 
 
 class Minimap2Plugin(Plugin):
@@ -14,7 +13,7 @@ class Minimap2Plugin(Plugin):
         index_name = genome.plugin["minimap2"]["index_name"]
         if force:
             # Start from scratch
-            rmtree(index_dir, ignore_errors=True)
+            rm_rf(index_dir)
         mkdir_p(index_dir)
 
         if not any(fname.endswith(".mmi") for fname in os.listdir(index_dir)):

--- a/genomepy/plugins/star.py
+++ b/genomepy/plugins/star.py
@@ -1,8 +1,8 @@
 import os
-from shutil import rmtree
 from genomepy.plugin import Plugin
 from genomepy.utils import (
     mkdir_p,
+    rm_rf,
     cmd_ok,
     run_index_cmd,
     gunzip_and_name,
@@ -18,7 +18,7 @@ class StarPlugin(Plugin):
             return
 
         index_dir = genome.plugin["star"]["index_dir"]
-        rmtree(index_dir, ignore_errors=True)
+        rm_rf(index_dir)
         mkdir_p(index_dir)
 
         # gunzip genome if bgzipped and return up-to-date genome name

--- a/genomepy/utils.py
+++ b/genomepy/utils.py
@@ -177,6 +177,11 @@ def mkdir_p(path):
     os.makedirs(path, exist_ok=True)
 
 
+def rm_rf(path):
+    """ 'rm -rf' in Python """
+    shutil.rmtree(path, ignore_errors=True)
+
+
 def cmd_ok(cmd):
     """Returns True if cmd can be run."""
     try:

--- a/tests/02_utils_test.py
+++ b/tests/02_utils_test.py
@@ -115,6 +115,18 @@ def test_mkdir_p(path="./tests/dir1/dir2/nestled_dir"):
     assert not os.path.isdir(path)
 
 
+def test_rm_rf(path="./tests/dir1/dir2/nestled_dir"):
+    genomepy.utils.mkdir_p(path)
+    assert os.path.isdir(path)
+
+    # try to remove an existing dir
+    genomepy.utils.rm_rf(path)
+    assert not os.path.isdir(path)
+
+    # try to remove a non-existing dir
+    genomepy.utils.rm_rf(path)
+
+
 def test_cmd_ok():
     assert genomepy.utils.cmd_ok("STAR")
     assert genomepy.utils.cmd_ok("bwa")

--- a/tests/04_genome_test.py
+++ b/tests/04_genome_test.py
@@ -1,7 +1,6 @@
 import genomepy
 import os
 import pytest
-import shutil
 
 from stat import S_IREAD, S_IRGRP, S_IROTH
 from genomepy.provider import ProviderBase
@@ -74,7 +73,7 @@ def test__parse_filename(genome="tests/data/small_genome.fa.gz"):
     g.genomes_dir = "tests/data/"
     filename = g._parse_filename(os.path.basename(genome))
     assert filename == "tests/data/small_genome/small_genome.fa.gz"
-    shutil.rmtree("tests/data/small_genome")
+    genomepy.utils.rm_rf("tests/data/small_genome")
 
     # genome not found
     with pytest.raises(FileNotFoundError):

--- a/tests/07_provider_ucsc_test.py
+++ b/tests/07_provider_ucsc_test.py
@@ -2,8 +2,8 @@ import genomepy
 import gzip
 import os
 import pytest
-import shutil
 
+from shutil import copyfile
 from tempfile import TemporaryDirectory
 
 
@@ -98,7 +98,7 @@ def test__post_process_download(p):
 
         # copy fa file for unmasking
         g = os.path.join(tmpdir, localname + ".fa")
-        shutil.copyfile("tests/data/gap.fa", g)
+        copyfile("tests/data/gap.fa", g)
 
         p._post_process_download(
             name=None, localname=localname, out_dir=tmpdir, mask="none"

--- a/tests/08_provider_ncbi_test.py
+++ b/tests/08_provider_ncbi_test.py
@@ -2,8 +2,8 @@ import genomepy
 import gzip
 import os
 import pytest
-import shutil
 
+from shutil import copyfile
 from tempfile import TemporaryDirectory
 
 
@@ -77,7 +77,7 @@ def test__post_process_download(p):
     with TemporaryDirectory(dir=out_dir) as tmpdir:
         # copy fa file for unmasking
         g = os.path.join(tmpdir, localname + ".fa")
-        shutil.copyfile("tests/data/gap.fa", g)
+        copyfile("tests/data/gap.fa", g)
 
         p._post_process_download(
             name=name, localname=localname, out_dir=tmpdir, mask="hard"

--- a/tests/10_functions_test.py
+++ b/tests/10_functions_test.py
@@ -1,7 +1,6 @@
 import genomepy
 import pytest
 import os
-import shutil
 
 from appdirs import user_config_dir, user_cache_dir
 from platform import system
@@ -164,7 +163,7 @@ def test__provider_selection():
     provider = None
     p = genomepy.functions._provider_selection(name, localname, genomes_dir, provider)
     assert "NcbiProvider" in str(p)
-    shutil.rmtree(os.path.dirname(readme))
+    genomepy.utils.rm_rf(os.path.dirname(readme))
 
     # lazy provider
     p = genomepy.functions._provider_selection(name, localname, genomes_dir, provider)
@@ -230,7 +229,7 @@ def test_generate_exports():
     exports = genomepy.functions.generate_exports()
     assert f"export TESTGENOME={path}" in exports
 
-    shutil.rmtree(os.path.join(gd, "testgenome"))
+    genomepy.utils.rm_rf(os.path.join(gd, "testgenome"))
 
 
 @pytest.mark.skipif(

--- a/tests/10_functions_test.py
+++ b/tests/10_functions_test.py
@@ -23,6 +23,8 @@ def test_clean():
     assert os.path.exists(my_cache_dir)  # dir exists
     assert not os.listdir(my_cache_dir)  # contains 0 pickles
 
+    genomepy.clean()  # no errors when cache dir is empty
+
 
 def test_manage_config(capsys):
     # make a new config

--- a/tests/11_plugins_test.py
+++ b/tests/11_plugins_test.py
@@ -2,9 +2,9 @@ import os
 import genomepy
 import pytest
 import re
-import shutil
 import subprocess as sp
 
+from shutil import copyfile
 from platform import system
 from time import sleep
 
@@ -49,11 +49,11 @@ def genome(request):
 
     genomes_dir = os.path.join(os.getcwd(), ".genomepy_plugin_tests")
     if os.path.exists(genomes_dir):
-        shutil.rmtree(genomes_dir)
+        genomepy.utils.rm_rf(genomes_dir)
     genome_dir = os.path.join(genomes_dir, name)
     genomepy.utils.mkdir_p(genome_dir)
     fname = os.path.join(genome_dir, f"{name}.fa.gz")
-    shutil.copyfile(fafile, fname)
+    copyfile(fafile, fname)
 
     # unzip genome if required
     if request.param == "unzipped":
@@ -62,7 +62,7 @@ def genome(request):
         # add annotation (for STAR and hisat2), but only once
         gtf_file = "tests/data/ce10.annotation.gtf.gz"
         aname = os.path.join(genome_dir, f"{name}.annotation.gtf.gz")
-        shutil.copyfile(gtf_file, aname)
+        copyfile(gtf_file, aname)
 
     return genomepy.Genome(name, genomes_dir=genomes_dir)
 
@@ -235,4 +235,4 @@ def test_plugin_cleanup():
 
     # cleanup after testing pluging
     genome_dir = os.path.join(os.getcwd(), ".genomepy_plugin_tests")
-    shutil.rmtree(genome_dir)
+    genomepy.utils.rm_rf(genome_dir)

--- a/tests/e02_install_options_test.py
+++ b/tests/e02_install_options_test.py
@@ -2,7 +2,6 @@ import genomepy
 import gzip
 import os
 import pytest
-import shutil
 
 from tempfile import mkdtemp
 from time import sleep
@@ -86,7 +85,7 @@ if not skip:
         t1 = os.path.getmtime(path)
         assert t0 != t1 if force else t0 == t1
 
-        shutil.rmtree(tmp)
+        genomepy.utils.rm_rf(tmp)
 
     def test_install_annotation_options(
         force, localname, genome="ASM14646v1", provider="NCBI"
@@ -136,4 +135,4 @@ if not skip:
         t1 = os.path.getmtime(gtf)
         assert t0 != t1 if force else t0 == t1
 
-        shutil.rmtree(tmp)
+        genomepy.utils.rm_rf(tmp)

--- a/tests/e03_human_genomes_test.py
+++ b/tests/e03_human_genomes_test.py
@@ -1,5 +1,4 @@
 import genomepy
-import shutil
 import pytest
 import os
 
@@ -22,7 +21,7 @@ if not skip:
         g = genomepy.Genome("hg38", genomes_dir=tmp)
         seq = g["chr6"][166168664:166168679]
         assert str(seq) == "CCTCCTCGCTCTCTT"
-        shutil.rmtree(tmp)
+        genomepy.utils.rm_rf(tmp)
 
     @pytest.mark.skipif(travis, reason="slow")
     def test_ensembl_human():
@@ -36,7 +35,7 @@ if not skip:
         g = genomepy.Genome("GRCh38.p13", genomes_dir=tmp)
         seq = g["6"][166168664:166168679]
         assert str(seq) == "CCTCCTCGCTCTCTT"
-        shutil.rmtree(tmp)
+        genomepy.utils.rm_rf(tmp)
 
     @pytest.mark.skipif(travis, reason="slow")
     def test_ncbi_human():
@@ -50,4 +49,4 @@ if not skip:
         g = genomepy.Genome("GRCh38.p13", genomes_dir=tmp)
         seq = g["6"][166168664:166168679]
         assert str(seq) == "CCTCCTCGCTCTCTT"
-        shutil.rmtree(tmp)
+        genomepy.utils.rm_rf(tmp)


### PR DESCRIPTION
`genomepy clean` could complain if the cache_dir does not exist before being called. Edge case (as I remake the cache dir after removal), but it prompted this little shorthand.