### PR TITLE
argparse action to parse genome from command line option

### DIFF
--- a/genomepy/argparse_support.py
+++ b/genomepy/argparse_support.py
@@ -24,7 +24,7 @@ def parse_genome(auto_install=False, genomes_dir=None):
                 if auto_install:
                     print("Trying to install it automatically using genomepy...")
                     install_genome(name, annotation=True, genomes_dir=genomes_dir)
-                    genome = Genome(name)
+                    genome = Genome(name, genomes_dir=genomes_dir)
                 else:
                     print("You can install it using `genomepy install`.")
                     sys.exit(1)

--- a/genomepy/argparse_support.py
+++ b/genomepy/argparse_support.py
@@ -1,0 +1,33 @@
+import sys
+import argparse
+from genomepy.functions import Genome, install_genome
+
+
+def parse_genome(auto_install=False, genomes_dir=None):
+    """argparse action for command-line genome option.
+
+    Parameters
+    ----------
+        auto_install : bool, optional
+            Install a genome if it's not found locally.
+
+        genomes_dir : str, optional
+            Directory to look for and/or insall genomes.
+    """
+
+    class GenomeAction(argparse.Action):
+        def __call__(self, parser, args, name, option_string=None):
+            try:
+                genome = Genome(name, genomes_dir=genomes_dir)
+            except FileNotFoundError:
+                print(f"Genome {name} not found!")
+                if auto_install:
+                    print("Trying to install it automatically using genomepy...")
+                    install_genome(name, annotation=True, genomes_dir=genomes_dir)
+                    genome = Genome(name)
+                else:
+                    print("You can install it using `genomepy install`.")
+                    sys.exit(1)
+            setattr(args, self.dest, genome)
+
+    return GenomeAction


### PR DESCRIPTION
This PR adds an ArgumentParser option to genomepy. With this, you can do the following (in another tool):

```
parser.add_argument(
            "-g", dest="genome", action=parse_genome()
        )
```

And then on the command-line:

```
my_tool -g hg38
```

`parse_args()` will then return a `Genome` object.

Optionally, you can also let genomepy install the genome automagically.

```
parser.add_argument(
            "-g", dest="genome", action=parse_genome(auto_install=True)
        )
```
