### PR TITLE
remove 'alt' regions by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
   - black --check setup.py genomepy/ tests/
   - flake8 setup.py genomepy/ tests/
   - pytest -vv --disable-pytest-warnings tests/*
-    --reruns 1 --reruns-delay 5
+    --reruns 1 --reruns-delay 10
     --cov=genomepy --cov-config=tests/.coveragerc --cov-report=xml
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
   - black --check setup.py genomepy/ tests/
   - flake8 setup.py genomepy/ tests/
   - pytest -vv --disable-pytest-warnings tests/*
-    --reruns 1 --reruns-delay 1
+    --reruns 1 --reruns-delay 5
     --cov=genomepy --cov-config=tests/.coveragerc --cov-report=xml
 
 after_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,23 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- `genomepy install` flag `-k/--keep-alt` to keep alternative regions
+
 ### Changed
 
 - added retries to UCSC and NCBI
 - added retries to Travis tests
 - Bucketcache improvements
-- `genomepy search` will keep searching after an exact match is found
+- `genomepy search` keeps searching after an exact match is found
+- `genomepy install` removes alternative regions by default
 
 ### Fixed
 
 - `genomepy clean` wont complain when there is nothing to clean
-- properly gzip the annotation.gtf if it was unzipped during sanitizing.
+- properly gzip the annotation.gtf if it was unzipped during sanitizing
 - `genomepy install` can use the URL provider again
+- `genomepy install` with `-f/--force` will overwrite previouse sizes and gaps files
 
 ## [0.9.0] - 2020-09-01
 

--- a/genomepy/cli.py
+++ b/genomepy/cli.py
@@ -80,6 +80,12 @@ general_install_options = {
         "help": "DNA masking: hard/soft/none (default: soft)",
         "default": "soft",
     },
+    "keep_alt": {
+        "short": "k",
+        "long": "keep-alt",
+        "help": "keep alternative regions",
+        "flag_value": True,
+    },
     "regex": {
         "short": "r",
         "long": "regex",
@@ -200,6 +206,7 @@ def install(
     genomes_dir,
     localname,
     mask,
+    keep_alt,
     regex,
     invert_match,
     bgzip,
@@ -217,6 +224,7 @@ def install(
         genomes_dir=genomes_dir,
         localname=localname,
         mask=mask,
+        keep_alt=keep_alt,
         regex=regex,
         invert_match=invert_match,
         bgzip=bgzip,

--- a/genomepy/functions.py
+++ b/genomepy/functions.py
@@ -12,6 +12,8 @@ from genomepy.provider import ProviderBase
 from genomepy.utils import (
     get_localname,
     get_genomes_dir,
+    generate_gap_bed,
+    generate_fa_sizes,
     glob_ext_files,
     mkdir_p,
     rm_rf,
@@ -216,6 +218,7 @@ def install_genome(
     genomes_dir=None,
     localname=None,
     mask="soft",
+    keep_alt=False,
     regex=None,
     invert_match=False,
     bgzip=None,
@@ -245,6 +248,11 @@ def install_genome(
 
     mask : str , optional
         Default is 'soft', choices 'hard'/'soft/'none' for respective masking level.
+
+    keep_alt : bool , optional
+        Some genomes contain alternative regions. These regions cause issues with
+        sequence alignment, as they are inherently duplications of the consensus regions.
+        Set to true to keep these alternative regions.
 
     regex : str , optional
         Regular expression to select specific chromosome / scaffold names.
@@ -298,6 +306,7 @@ def install_genome(
             name,
             genomes_dir,
             mask=mask,
+            keep_alt=keep_alt,
             regex=regex,
             invert_match=invert_match,
             localname=localname,
@@ -313,6 +322,10 @@ def install_genome(
     g = None
     if genome_found:
         g = Genome(localname, genomes_dir=genomes_dir)
+        if force:
+            # overwrite previous versions
+            generate_fa_sizes(g.genome_file, g.sizes_file)
+            generate_gap_bed(g.genome_file, g.gaps_file)
 
     # Check if any annotation flags are given, if annotation already exists, or if downloading is forced
     if any(


### PR DESCRIPTION
sidenote: now also remakes the sizes and gaps file when force downloading the genome. 
if you use the force flag while downloading the genome for the first time, it does this twice, but that shouldn't be too much extra work.