### PR TITLE
Fix 142

### DIFF
--- a/genomepy/plugins/gmap.py
+++ b/genomepy/plugins/gmap.py
@@ -1,6 +1,6 @@
 import os.path
 from shutil import move
-from tempfile import TemporaryDirectory
+from tempfile import mkdtemp
 from genomepy.plugin import Plugin
 from genomepy.utils import cmd_ok, rm_rf, run_index_cmd, gunzip_and_name, bgzip_and_name
 
@@ -22,14 +22,15 @@ class GmapPlugin(Plugin):
 
             # gmap outputs a folder named genome.name
             # its content is moved to index dir, consistent with other plugins
-            with TemporaryDirectory() as tmpdir:
-                # Create index
-                cmd = f"gmap_build -D {tmpdir} -d {genome.name} {fname}"
-                run_index_cmd("gmap", cmd)
+            tmp_dir = mkdtemp(dir=".")
+            # Create index
+            cmd = f"gmap_build -D {tmp_dir} -d {genome.name} {fname}"
+            run_index_cmd("gmap", cmd)
 
-                # Move files to index_dir
-                src = os.path.join(tmpdir, genome.name)
-                move(src, index_dir)
+            # Move files to index_dir
+            src = os.path.join(tmp_dir, genome.name)
+            move(src, index_dir)
+            rm_rf(tmp_dir)
 
             # re-zip genome if unzipped
             bgzip_and_name(fname, bgzip)

--- a/genomepy/provider.py
+++ b/genomepy/provider.py
@@ -246,9 +246,7 @@ class ProviderBase(object):
 
         urlcleanup()
         download_file(link, fname)
-        sys.stderr.write(
-            "Genome download successful, starting post processing...\n"
-        )
+        sys.stderr.write("Genome download successful, starting post processing...\n")
 
         # unzip genome
         if link.endswith(".tar.gz"):


### PR DESCRIPTION
There seems to be a new issue with tempfile's TemporaryDirectory function: https://bugs.python.org/issue35144
We only use the function 3 times, so its replaced for now.

To clean up the temporary directories, we now use our rm_rf function, which should ignore any OSErrors. Worst case scenario would be an unfindable/unremovable file keeps the directory from being deleted. Seems better than a crash...