### PR TITLE
slight reorganization of the mygene functionality

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - bucketcache
   - click
   - colorama
+  - joblib
   - loguru
   - mygene
   - norns>=0.1.5

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ requires = [
     "bucketcache",
     "click",
     "colorama",
+    "joblib",
     "loguru",
     "mygene",
     "norns>=0.1.5",

--- a/tests/test_05_annotation.py
+++ b/tests/test_05_annotation.py
@@ -6,6 +6,7 @@ import pytest
 
 import genomepy
 import genomepy.utils
+from genomepy.annotation import query_mygene
 
 
 def test_get_column():
@@ -363,3 +364,8 @@ def test_sanitize(caplog):
     assert metadata["sanitized annotation"] == "contigs fixed and filtered"
 
     genomepy.utils.rm_rf(tmp_dir)
+
+
+def test_query_mygene():
+    result = query_mygene(["ENST00000449992"], 9606, "symbol")
+    assert result.loc["ENST00000449992", "symbol"] == "TP63"


### PR DESCRIPTION
Two changes:

* The mygene query functionality can now also be used without creating an annotation object.
* The mygene result is cached (using joblib), saving a lot of time for repeated queries.