### PR TITLE
attempt to cache conda on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,29 +23,25 @@ cache:
 
 before_install:
   # install miniconda or use the cache
+  - if test -e $HOME/miniconda/bin; then
+      echo "Miniconda already installed";
+
+      export PATH=$HOME/miniconda/bin:$PATH;
+      conda config --set always_yes yes;
+      mamba update -n genomepy -f environment.yml;
+    fi
   - if ! test -e $HOME/miniconda/bin; then
       echo "Installing miniconda";
 
       CONDA_OS=$([ "$TRAVIS_OS_NAME" = "linux" ] && echo "Linux" || echo "MacOSX");
       wget https://repo.continuum.io/miniconda/Miniconda3-latest-${CONDA_OS}-x86_64.sh -O miniconda.sh;
-
       chmod +x miniconda.sh;
       ./miniconda.sh -b -p $HOME/miniconda -f;
 
       export PATH=$HOME/miniconda/bin:$PATH;
       conda config --set always_yes yes;
       conda install conda-forge::mamba;
-
-      echo "Installing genomepy dependencies";
-      mamba env create -n genomepy python=$PYTHON_VERSION -f environment.yml
-    else
-      echo "Miniconda already installed";
-
-      export PATH=$HOME/miniconda/bin:$PATH;
-      conda config --set always_yes yes;
-
-      echo "Updating genomepy dependencies";
-      mamba update -n genomepy -f environment.yml
+      mamba env create -n genomepy python=$PYTHON_VERSION -f environment.yml;
     fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ cache:
     - $HOME/.condarc
 
 before_install:
+  # install miniconda or use the cache
   - if [ ! -f $HOME/miniconda3/bin/mamba ]; then
-      # install miniconda
       if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
       else
@@ -37,7 +37,6 @@ before_install:
       conda config --set always_yes yes
       conda install conda-forge::mamba
     else
-      # use cached miniconda
       export PATH=$HOME/miniconda/bin:$PATH
       conda config --set always_yes yes
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,15 +34,19 @@ before_install:
       export PATH=$HOME/miniconda/bin:$PATH;
       conda config --set always_yes yes;
       conda install conda-forge::mamba;
+
+      echo "Installing genomepy dependencies";
+      mamba env create -n genomepy python=$PYTHON_VERSION -f environment.yml
     else
       echo "Miniconda already installed";
       export PATH=$HOME/miniconda/bin:$PATH;
       conda config --set always_yes yes;
+
+      echo "Updating genomepy dependencies";
+      mamba update -n genomepy -f environment.yml
     fi
 
 install:
-  # install genomepy
-  - mamba env create -n genomepy python=$PYTHON_VERSION -f environment.yml  # [ ! $(cat ~/.conda/environments.txt | grep envs/genomepy) ] && mamba env create -n genomepy python=$PYTHON_VERSION -f environment.yml || mamba update -n genomepy -f environment.yml
   - source activate genomepy
   - python setup.py develop
   - python setup.py build

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
 
 install:
   # install genomepy
-  - mamba env create -n genomepy python=$PYTHON_VERSION -f environment.yml  # [ ! $(cat ~/.conda/environments.txt | grep envs/genomepy) ] && mamba env create -n genomepy python=$PYTHON_VERSION -f environment.yml || mamba update -n genomepy -f environment.yml
+  - mamba env create -n genomepy python=$PYTHON_VERSION -f environment.yml  # [ ! $(cat ~/.conda/environments.txt | grep envs/genomepy) ] && mamba env create -n genomepy python=$PYTHON_VERSION -f environment.yml || mamba update -n genomepy -f environment.yml #
   - source activate genomepy
   - python setup.py develop
   - python setup.py build

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ os:
 env:
   global:
     - CC_TEST_REPORTER_ID=951f438ac8a0fa93801ff0bf69922df59fe03800bf7ea8ab77a3c26cda444979
-    - CONDA_URL=https://repo.continuum.io/miniconda/Miniconda3-latest-$([ "$TRAVIS_OS_NAME" = "linux" ] && echo "Linux" || echo "MacOSX")-x86_64.sh
   jobs:
     - PYTHON_VERSION=3.6
 
@@ -25,7 +24,8 @@ cache:
 before_install:
   # install miniconda or use the cache
   - if [ ! -f $HOME/miniconda3/bin/mamba ]; then
-      wget $CONDA_URL -O miniconda.sh;
+      CONDA_OS=$([ "$TRAVIS_OS_NAME" = "linux" ] && echo "Linux" || echo "MacOSX");
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-${CONDA_OS}-x86_64.sh -O miniconda.sh;
       chmod +x miniconda.sh;
       ./miniconda.sh -b -p $HOME/miniconda -f;
       export PATH=$HOME/miniconda/bin:$PATH;

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,19 +19,23 @@ env:
 
 cache:
   directories:
-    - $HOME/miniconda3
+    - $HOME/miniconda
 
 before_install:
   # install miniconda or use the cache
-  - if [ ! -f $HOME/miniconda3/bin/mamba ]; then
+  - if test -e $HOME/miniconda/bin; then
+      echo "Installing miniconda";
       CONDA_OS=$([ "$TRAVIS_OS_NAME" = "linux" ] && echo "Linux" || echo "MacOSX");
       wget https://repo.continuum.io/miniconda/Miniconda3-latest-${CONDA_OS}-x86_64.sh -O miniconda.sh;
+
       chmod +x miniconda.sh;
       ./miniconda.sh -b -p $HOME/miniconda -f;
+
       export PATH=$HOME/miniconda/bin:$PATH;
       conda config --set always_yes yes;
       conda install conda-forge::mamba;
     else
+      echo "Miniconda already installed";
       export PATH=$HOME/miniconda/bin:$PATH;
       conda config --set always_yes yes;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,9 @@ before_script:
     fi
 
 script:
-  - pytest -vv --disable-pytest-warnings tests/test_01_basic.py
+  - black --check setup.py genomepy/ tests/
+  - flake8 setup.py genomepy/ tests/
+  - pytest -vv --disable-pytest-warnings tests/*
     --reruns 1 --reruns-delay 10
     --cov=genomepy --cov-config=tests/.coveragerc --cov-report=xml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,36 +14,31 @@ os:
 env:
   global:
     - CC_TEST_REPORTER_ID=951f438ac8a0fa93801ff0bf69922df59fe03800bf7ea8ab77a3c26cda444979
+    - CONDA_URL=https://repo.continuum.io/miniconda/Miniconda3-latest-$([ "$TRAVIS_OS_NAME" = "linux" ] && echo "Linux" || echo "MacOSX")-x86_64.sh
   jobs:
     - PYTHON_VERSION=3.6
 
 cache:
   directories:
     - $HOME/miniconda3
-    - $HOME/.conda
-    - $HOME/.condarc
 
 before_install:
   # install miniconda or use the cache
   - if [ ! -f $HOME/miniconda3/bin/mamba ]; then
-      if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-      else
-        wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
-      fi
-      chmod +x miniconda.sh
-      ./miniconda.sh -b -p $HOME/miniconda -f
-      export PATH=$HOME/miniconda/bin:$PATH
-      conda config --set always_yes yes
-      conda install conda-forge::mamba
+      wget $CONDA_URL -O miniconda.sh;
+      chmod +x miniconda.sh;
+      ./miniconda.sh -b -p $HOME/miniconda -f;
+      export PATH=$HOME/miniconda/bin:$PATH;
+      conda config --set always_yes yes;
+      conda install conda-forge::mamba;
     else
-      export PATH=$HOME/miniconda/bin:$PATH
-      conda config --set always_yes yes
+      export PATH=$HOME/miniconda/bin:$PATH;
+      conda config --set always_yes yes;
     fi
 
 install:
   # install genomepy
-  - mamba env create -n genomepy python=$PYTHON_VERSION -f environment.yml
+  - mamba env create -n genomepy python=$PYTHON_VERSION -f environment.yml  # [ ! $(cat ~/.conda/environments.txt | grep envs/genomepy) ] && mamba env create -n genomepy python=$PYTHON_VERSION -f environment.yml || mamba update -n genomepy -f environment.yml
   - source activate genomepy
   - python setup.py develop
   - python setup.py build

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ env:
 
 cache:
   directories:
-    - $HOME/miniconda
+    - $HOME/miniconda3
 before_cache:
-  - conda clean --all # needed here?
+  - conda clean --all
 
 before_install:
   # install miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,12 @@ env:
   jobs:
     - PYTHON_VERSION=3.6
 
+cache:
+  directories:
+    - $HOME/miniconda
+before_cache:
+  - conda clean --all
+
 before_install:
   # install miniconda
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
@@ -50,9 +56,7 @@ before_script:
     fi
 
 script:
-  - black --check setup.py genomepy/ tests/
-  - flake8 setup.py genomepy/ tests/
-  - pytest -vv --disable-pytest-warnings tests/*
+  - pytest -vv --disable-pytest-warnings tests/test_01_basic.py
     --reruns 1 --reruns-delay 10
     --cov=genomepy --cov-config=tests/.coveragerc --cov-report=xml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_install:
   # install miniconda or use the cache
   - if ! test -e $HOME/miniconda/bin; then
       echo "Installing miniconda";
+
       CONDA_OS=$([ "$TRAVIS_OS_NAME" = "linux" ] && echo "Linux" || echo "MacOSX");
       wget https://repo.continuum.io/miniconda/Miniconda3-latest-${CONDA_OS}-x86_64.sh -O miniconda.sh;
 
@@ -39,6 +40,7 @@ before_install:
       mamba env create -n genomepy python=$PYTHON_VERSION -f environment.yml
     else
       echo "Miniconda already installed";
+
       export PATH=$HOME/miniconda/bin:$PATH;
       conda config --set always_yes yes;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ cache:
   directories:
     - $HOME/miniconda
 before_cache:
-  - conda clean --all
+  - conda clean --all # needed here?
 
 before_install:
   # install miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ cache:
 
 before_install:
   # install miniconda or use the cache
-  - if test -e $HOME/miniconda/bin; then
+  - if ! test -e $HOME/miniconda/bin; then
       echo "Installing miniconda";
       CONDA_OS=$([ "$TRAVIS_OS_NAME" = "linux" ] && echo "Linux" || echo "MacOSX");
       wget https://repo.continuum.io/miniconda/Miniconda3-latest-${CONDA_OS}-x86_64.sh -O miniconda.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_install:
 
 install:
   # install genomepy
-  - mamba env create -n genomepy python=$PYTHON_VERSION -f environment.yml  # [ ! $(cat ~/.conda/environments.txt | grep envs/genomepy) ] && mamba env create -n genomepy python=$PYTHON_VERSION -f environment.yml || mamba update -n genomepy -f environment.yml #
+  - mamba env create -n genomepy python=$PYTHON_VERSION -f environment.yml  # [ ! $(cat ~/.conda/environments.txt | grep envs/genomepy) ] && mamba env create -n genomepy python=$PYTHON_VERSION -f environment.yml || mamba update -n genomepy -f environment.yml
   - source activate genomepy
   - python setup.py develop
   - python setup.py build

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,23 +20,30 @@ env:
 cache:
   directories:
     - $HOME/miniconda3
-before_cache:
-  - conda clean --all
+    - $HOME/.conda
+    - $HOME/.condarc
 
 before_install:
-  # install miniconda
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+  - if [ ! -f $HOME/miniconda3/bin/mamba ]; then
+      # install miniconda
+      if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+      else
+        wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
+      fi
+      chmod +x miniconda.sh
+      ./miniconda.sh -b -p $HOME/miniconda -f
+      export PATH=$HOME/miniconda/bin:$PATH
+      conda config --set always_yes yes
+      conda install conda-forge::mamba
     else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
+      # use cached miniconda
+      export PATH=$HOME/miniconda/bin:$PATH
+      conda config --set always_yes yes
     fi
-  - chmod +x miniconda.sh
-  - ./miniconda.sh -b -p $HOME/miniconda -f
-  - export PATH=$HOME/miniconda/bin:$PATH
-  - conda config --set always_yes yes
-  - conda install conda-forge::mamba
 
 install:
+  # install genomepy
   - mamba env create -n genomepy python=$PYTHON_VERSION -f environment.yml
   - source activate genomepy
   - python setup.py develop
@@ -44,11 +51,6 @@ install:
 
 before_script:
   # install codeclimate test coverage
-#  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-#      wget -O cc-test-reporter https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64;
-#      chmod +x ./cc-test-reporter;
-#      ./cc-test-reporter before-build;
-#    fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       wget -O cc-test-reporter https://codeclimate.com/downloads/test-reporter/test-reporter-latest-darwin-amd64;
       chmod +x ./cc-test-reporter;
@@ -59,6 +61,9 @@ script:
   - pytest -vv --disable-pytest-warnings tests/test_01_basic.py
     --reruns 1 --reruns-delay 10
     --cov=genomepy --cov-config=tests/.coveragerc --cov-report=xml
+
+before_cache:
+  - conda clean --all
 
 after_script:
   # send the coverage data to Code Climate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - `genomepy install` only zips annotation files if the genome is zipped (with the bgzip flag)
 - NCBI provider should be parsed faster
 - new dependency: pandas
+- travis caches conda for faster testing
 
 ### Fixed
 - broken URLs should keep genomepy occupied for less long (check_url will immediately return on "Not Found" errors 404/450)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - `genomepy install` only zips annotation files if the genome is zipped (with the bgzip flag)
 - NCBI provider should be parsed faster
 - new dependency: pandas
-- travis caches conda for faster testing
 
 ### Fixed
 - broken URLs should keep genomepy occupied for less long (check_url will immediately return on "Not Found" errors 404/450)


### PR DESCRIPTION
Testing goes faster if we don't have to install conda every time. This PR caches miniconda, mamba and the genomepy env.

Upon rerun, the genomepy environment is updated.
Finally, to minimize storage space on travis, we clean the conda package cache before (re)caching.
