### PR TITLE
use other annotation files

### DIFF
--- a/genomepy/annotation/__init__.py
+++ b/genomepy/annotation/__init__.py
@@ -1,5 +1,6 @@
 import os
 import re
+from pathlib import Path
 from typing import Iterable, Optional, Union
 
 import numpy as np
@@ -22,11 +23,15 @@ class Annotation:
 
     Parameters
     ----------
-    name : str
-        Genome name
+    genome : str
+        Genome name.
 
-    genomes_dir : str
-        Genomes installation directory
+    name : str, optional
+        Name of annotation file. If name is not specified, then the default annotation
+        for the genome is used.
+
+    genomes_dir : str, optional
+        Genomes installation directory.
 
     Returns
     -------
@@ -45,23 +50,38 @@ class Annotation:
     genome_contigs: list = None
     annotation_contigs: list = None
 
-    def __init__(self, name: str, genomes_dir: str = None):
-        self.name = name
-        self.genome_dir = os.path.join(get_genomes_dir(genomes_dir), name)
+    def __init__(self, genome: str, name: str = None, genomes_dir: str = None):
+        self.genome = genome
+        self.genome_dir = os.path.join(get_genomes_dir(genomes_dir), genome)
+        if not os.path.exists(self.genome_dir):
+            raise ValueError(f"Genome {self.genome} not found!")
 
-        # annotation files
-        self.readme_file = _get_file(self.genome_dir, "README.txt", False)
-        self.annotation_gtf_file = _get_file(
-            self.genome_dir, f"{self.name}.annotation.gtf"
-        )
-        self.annotation_bed_file = _get_file(
-            self.genome_dir, f"{self.name}.annotation.bed"
-        )
+        # annotation file provided
+        if name:
+            suffixes = Path(name).suffixes[-2:]
+            print(suffixes)
+            if ".bed" in suffixes or ".BED" in suffixes:
+                self.annotation_bed_file = name
+            elif ".gtf" in suffixes or ".GTF" in suffixes:
+                self.annotation_gtf_file = name
+            else:
+                raise NotImplementedError(
+                    "Only (gzipped) bed and gtf files are supported at the moment!"
+                )
+        else:
+            # annotation files
+            self.annotation_gtf_file = _get_file(
+                self.genome_dir, f"{self.genome}.annotation.gtf"
+            )
+            self.annotation_bed_file = _get_file(
+                self.genome_dir, f"{self.genome}.annotation.bed"
+            )
 
         # genome files
-        self.genome_file = _get_file(self.genome_dir, f"{self.name}.fa", False)
-        self.index_file = _get_file(self.genome_dir, f"{self.name}.fa.fai", False)
-        self.sizes_file = _get_file(self.genome_dir, f"{self.name}.fa.sizes", False)
+        self.readme_file = _get_file(self.genome_dir, "README.txt", False)
+        self.genome_file = _get_file(self.genome_dir, f"{self.genome}.fa", False)
+        self.index_file = _get_file(self.genome_dir, f"{self.genome}.fa.fai", False)
+        self.sizes_file = _get_file(self.genome_dir, f"{self.genome}.fa.sizes", False)
 
     # lazy attributes
     def __getattribute__(self, name):
@@ -71,12 +91,12 @@ class Annotation:
 
         # if the attribute is None/empty, check if it is a lazy attribute
         if name == "bed":
-            _check_property(self.annotation_bed_file, f"{self.name}.annotation.bed")
+            _check_property(self.annotation_bed_file, f"{self.genome}.annotation.bed")
             val = read_annot(self.annotation_bed_file)
             setattr(self, name, val)
 
         elif name == "gtf":
-            _check_property(self.annotation_gtf_file, f"{self.name}.annotation.gtf")
+            _check_property(self.annotation_gtf_file, f"{self.genome}.annotation.gtf")
             val = read_annot(self.annotation_gtf_file)
             setattr(self, name, val)
 
@@ -91,7 +111,7 @@ class Annotation:
             setattr(self, name, val)
 
         elif name == "genome_contigs":
-            _check_property(self.sizes_file, f"{self.name}.fa.sizes")
+            _check_property(self.sizes_file, f"{self.genome}.fa.sizes")
             val = list(
                 set(pd.read_csv(self.sizes_file, sep="\t", header=None, dtype=str)[0])
             )
@@ -204,7 +224,7 @@ class Annotation:
             Chromosome mapping.
         """
         genomes_dir = os.path.dirname(self.genome_dir)
-        mapping = map_locations(self.name, to, genomes_dir)
+        mapping = map_locations(self.genome, to, genomes_dir)
         if mapping is None:
             return
 

--- a/genomepy/annotation/__init__.py
+++ b/genomepy/annotation/__init__.py
@@ -59,7 +59,6 @@ class Annotation:
         # annotation file provided
         if name:
             suffixes = Path(name).suffixes[-2:]
-            print(suffixes)
             if ".bed" in suffixes or ".BED" in suffixes:
                 self.annotation_bed_file = name
             elif ".gtf" in suffixes or ".GTF" in suffixes:

--- a/genomepy/annotation/sanitize.py
+++ b/genomepy/annotation/sanitize.py
@@ -28,7 +28,7 @@ def sanitize(self, match=True, filter=True, overwrite=False):
     -------
     updated Annotation class instance
     """
-    _check_property(self.genome_file, f"{self.name}.fa")
+    _check_property(self.genome_file, f"{self.genome}.fa")
 
     cd = {}
     if match:

--- a/genomepy/functions.py
+++ b/genomepy/functions.py
@@ -224,7 +224,7 @@ def install_genome(
         ) and bool(glob_ext_files(out_dir, "annotation.bed"))
 
     if annotation_downloaded:
-        annotation = Annotation(localname, genomes_dir)
+        annotation = Annotation(localname, genomes_dir=genomes_dir)
         if genome_found and not (skip_matching and skip_filter):
             annotation.sanitize(not skip_matching, not skip_filter, True)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,7 +80,7 @@ def annot():
         f.write(
             """chrM\t15307\t16448\tNP_059343.1\t42\t+\t15307\t16448\t0\t1\t1141,\t0,"""
         )
-    yield genomepy.Annotation(name="regexp", genomes_dir="tests/data")
+    yield genomepy.Annotation(genome="regexp", genomes_dir="tests/data")
 
     teardown("tests/data/regexp/regexp.")
 

--- a/tests/test_13_annotation.py
+++ b/tests/test_13_annotation.py
@@ -28,19 +28,23 @@ def test_annotation_init(caplog, annot):
     g2 = "tests/data/data.annotation.gtf.gz"
     with genomepy.files._open(g2, "w") as fa:
         fa.write("2")
-    a = genomepy.Annotation(name="data", genomes_dir="tests")
+    a = genomepy.Annotation(genome="data", genomes_dir="tests")
     assert a.annotation_gtf_file.endswith(g1)
     genomepy.utils.rm_rf(g1)
     genomepy.utils.rm_rf(g2)
 
     # not enough GTF files
-    genomepy.Annotation(name="never_existed", genomes_dir="tests/data")
-    assert "Could not find 'never_existed.annotation.bed" in caplog.text
-    assert "Could not find 'never_existed.annotation.gtf" in caplog.text
+    genomepy.Annotation(genome="empty", genomes_dir="tests/data")
+    assert "Could not find 'empty.annotation.bed" in caplog.text
+    assert "Could not find 'empty.annotation.gtf" in caplog.text
+
+    # Genome doesn't exist
+    with pytest.raises(ValueError):
+        genomepy.Annotation(genome="never_existed", genomes_dir="tests/data")
 
 
 def test_named_gtf():
-    a = genomepy.Annotation("sacCer3", "tests/data")
+    a = genomepy.Annotation("sacCer3", genomes_dir="tests/data")
     df = a.named_gtf
     assert df.index.name == "gene_name"
     assert str(a.gtf.index.dtype) == "int64"
@@ -56,7 +60,7 @@ def test_genes(annot):
 
 
 def test_gene_coords(caplog):
-    a = genomepy.Annotation("sacCer3", "tests/data")
+    a = genomepy.Annotation("sacCer3", genomes_dir="tests/data")
 
     bed_genes = a.genes()[0:10]
     c = a.gene_coords(bed_genes, "bed")
@@ -77,7 +81,7 @@ def test_gene_coords(caplog):
 
 
 def test_map_locations():
-    a = genomepy.Annotation("sacCer3", "tests/data")
+    a = genomepy.Annotation("sacCer3", genomes_dir="tests/data")
 
     # BED + Ensembl
     ens = a.map_locations(annot=a.bed.head(1), to="Ensembl")
@@ -100,7 +104,7 @@ def test_filter_regex():
     with open(gtf_file, "w") as f:
         f.write("chr2\tcool_gene\n")
         f.write("chromosome3\tboring_gene\n")
-    a = genomepy.annotation.Annotation("regexp", "tests/data")
+    a = genomepy.annotation.Annotation("regexp", genomes_dir="tests/data")
     gtf_df = pd.read_csv(gtf_file, sep="\t", header=None)
 
     df = a.filter_regex(gtf_df, regex=".*2")
@@ -165,7 +169,7 @@ def test_generate_annot():
             "chr1\tgenomepy\texon\t1\t100\t.\t+\t.\t"
             'gene_id "ENSGP1234"; transcript_id "GP_1234.1";  gene_name "GP";\n'
         )
-    a = genomepy.annotation.Annotation("data", "tests")
+    a = genomepy.annotation.Annotation("data", genomes_dir="tests")
 
     # BED file before & after
     with genomepy.files._open(a.annotation_bed_file, "r") as f:
@@ -195,7 +199,7 @@ def test_generate_annot():
 
 
 def test__parse_annot():
-    a = genomepy.Annotation("sacCer3", "tests/data")
+    a = genomepy.Annotation("sacCer3", genomes_dir="tests/data")
     df = genomepy.annotation.utils._parse_annot(a, "bed")
     assert df.equals(a.bed)
     df = genomepy.annotation.utils._parse_annot(a, "gtf")
@@ -212,12 +216,12 @@ def test__parse_annot():
 
 def test_match_contigs():
     # nothing to work with
-    a = genomepy.Annotation("sacCer3", "tests/data")
+    a = genomepy.Annotation("sacCer3", genomes_dir="tests/data")
     cd = genomepy.annotation.sanitize.match_contigs(a)
     assert cd is None
 
     # one missing contig, one fixable contig
-    a = genomepy.Annotation("sanitize", "tests/data")
+    a = genomepy.Annotation("sanitize", genomes_dir="tests/data")
     before = a.gtf
     cd = genomepy.annotation.sanitize.match_contigs(a)
     after = a.gtf
@@ -229,7 +233,7 @@ def test_match_contigs():
 
 
 def test_filter_contigs():
-    a = genomepy.Annotation("sacCer3", "tests/data")
+    a = genomepy.Annotation("sacCer3", genomes_dir="tests/data")
     assert "chrV" not in a.bed.chrom.unique()
 
     # add a chromosome to the BED not present in the genome
@@ -271,7 +275,7 @@ def test_document_sanitizing():
 
 
 def test_sanitize():
-    a = genomepy.Annotation("sanitize", "tests/data")
+    a = genomepy.Annotation("sanitize", genomes_dir="tests/data")
 
     a.sanitize(overwrite=False)
     assert a.gtf.shape == (4, 9)
@@ -282,7 +286,7 @@ def test_sanitize():
 
 
 def test_map_genes():
-    a = genomepy.Annotation("GRCz11", "tests/data")
+    a = genomepy.Annotation("GRCz11", genomes_dir="tests/data")
 
     bed = a.bed.head()
     transcript_ids = bed.name.to_list()
@@ -331,13 +335,13 @@ def test_parse_mygene_input():
 
 def test_ensembl_genome_info():
     # Works
-    a = genomepy.Annotation("sacCer3", "tests/data")
+    a = genomepy.Annotation("sacCer3", genomes_dir="tests/data")
     egi = genomepy.annotation.mygene.ensembl_genome_info(a)
     assert egi == ("R64-1-1", "GCA_000146045.2", 4932)
     # genomepy.utils.rm_rf(os.path.join(a.genome_dir, "assembly_report.txt"))
 
     # No readme
-    a = genomepy.Annotation("regexp", "tests/data")
+    a = genomepy.Annotation("regexp", genomes_dir="tests/data")
     readme_file = os.path.join(a.genome_dir, "README.txt")
     with pytest.raises(FileNotFoundError):
         genomepy.annotation.mygene.ensembl_genome_info(a)
@@ -345,7 +349,7 @@ def test_ensembl_genome_info():
     # Empty readme
     with open(readme_file, "w") as f:
         f.write("\n")
-    a = genomepy.Annotation("regexp", "tests/data")
+    a = genomepy.Annotation("regexp", genomes_dir="tests/data")
     egi = genomepy.annotation.mygene.ensembl_genome_info(a)
     assert egi is None
     genomepy.utils.rm_rf(readme_file)

--- a/tests/test_13_annotation.py
+++ b/tests/test_13_annotation.py
@@ -43,6 +43,32 @@ def test_annotation_init(caplog, annot):
         genomepy.Annotation(genome="never_existed", genomes_dir="tests/data")
 
 
+def test_custom_annotation():
+    for fname in [
+        "tests/data/custom.annotation.bed",
+        "tests/data/custom.annotation.bed.gz",
+    ]:
+        a = genomepy.Annotation(name=fname, genome="sacCer3", genomes_dir="tests/data")
+        assert a.bed.shape[0] == 10
+
+        with pytest.raises(AttributeError):
+            a.gtf
+
+    for fname in [
+        "tests/data/custom.annotation.gtf",
+        "tests/data/custom.annotation.gtf.gz",
+    ]:
+        a = genomepy.Annotation(name=fname, genome="sacCer3", genomes_dir="tests/data")
+        assert a.gtf.shape[0] == 45
+        with pytest.raises(AttributeError):
+            a.bed
+
+    with pytest.raises(NotImplementedError):
+        a = genomepy.Annotation(
+            name="tests/data/regions.txt", genome="sacCer3", genomes_dir="tests/data"
+        )
+
+
 def test_named_gtf():
     a = genomepy.Annotation("sacCer3", genomes_dir="tests/data")
     df = a.named_gtf


### PR DESCRIPTION
This PR adds the option to do this:

```
a = Annotation("mm10", name="/home/heeringen/ceph/test/test.bed")
```

Create an `Annotation()` object, where the annotation doesn't come from the genome (similar as to how you can initialize `Genome()` with an arbitrary FASTA file).
This enables `a.map_genes()` for any annotation file that you may have, as long as you have the relevant genome.
