### PR TITLE
Ensembl to http

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - extened docstrings
+- Ensembl's GRCh37 can now be downloaded through genomepy
 
 ### Changed
 - UCSC annotation conversion tool settings tweaked. Better results with source gff files.
+- Ensembl now uses HTTP instead of FTP (in some cases). This improves stability on some servers.
+
+### Fixed
+- Ensembl annotations from previous releases can now be downloaded as intended.
 
 ## [0.10.0] - 2021-07-30
 

--- a/genomepy/providers/base.py
+++ b/genomepy/providers/base.py
@@ -115,7 +115,7 @@ class BaseProvider:
             if accession.startswith(("GCA", "GCF")):
                 return accession
 
-    def annotation_links(self, name: str) -> List[str]:
+    def annotation_links(self, name: str, **kwargs) -> List[str]:
         """
         Return available gene annotation links (http/ftp) for a genome
 
@@ -130,7 +130,7 @@ class BaseProvider:
             Gene annotation links
         """
         if "annotations" not in self.genomes[safe(name)]:
-            links = self.get_annotation_download_links(name)
+            links = self.get_annotation_download_links(name, **kwargs)
             self.genomes[safe(name)]["annotations"] = links
         return self.genomes[safe(name)]["annotations"]
 
@@ -258,7 +258,7 @@ class BaseProvider:
         GenomeDownloadError
             if no functional link was found
         """
-        links = self.annotation_links(name)
+        links = self.annotation_links(name, **kwargs)
         if links:
             return links[0]
         raise GenomeDownloadError(

--- a/genomepy/providers/ensembl.py
+++ b/genomepy/providers/ensembl.py
@@ -203,10 +203,10 @@ def add_grch37(genomes):
             "http://ftp.ensembl.org/pub/grch37/release-{}/gtf/"
             "homo_sapiens/Homo_sapiens.GRCh37.87.gtf.gz"
         ),
-        "assembly_accession": "GCA_000001405.1",
+        "assembly_accession": "GCA_000001405.14",
         "taxonomy_id": 9606,
         "name": "human",
-        "scientific_name": "Homo Sapiens",
+        "scientific_name": "Homo sapiens",
         "url_name": "Homo_sapiens",
         "assembly_name": "GRCh37",
         "division": "vertebrates",

--- a/genomepy/providers/ucsc.py
+++ b/genomepy/providers/ucsc.py
@@ -151,7 +151,7 @@ class UcscProvider(BaseProvider):
 
         return "na"
 
-    def annotation_links(self, name) -> List[str]:
+    def annotation_links(self, name, **kwargs) -> List[str]:
         """
         Return a sorted list of available gene annotation types for a genome
 

--- a/tests/test_e01_link_options.py
+++ b/tests/test_e01_link_options.py
@@ -1,7 +1,5 @@
 import pytest
 
-from tests import linux, travis
-
 skip = False
 if not skip:
 
@@ -17,7 +15,6 @@ if not skip:
     def masking(request):
         return request.param
 
-    @pytest.mark.skipif(travis and linux, reason="FTP does not work on Travis-Linux")
     def test_ensembl_genome_download_links(assembly, masking, release_version, ensembl):
         """Test Ensembl links with various options
 
@@ -32,7 +29,6 @@ if not skip:
             "GRCh38.p13", mask=mask, toplevel=toplevel, version=version
         )
 
-    @pytest.mark.skipif(travis and linux, reason="FTP does not work on Travis-Linux")
     def test_ensemblgenomes_genome_download_links(masking, ensembl):
         """Test Ensembl FTP links for various genomes
 


### PR DESCRIPTION
this PR does 3 things for Ensembl:
- no longer using FTP
- added GRCh37 to the genomes (it has its own directory, which sucks, but its popular...)
- fixed a bug where you would always get the latest release version for your annotations.