### PR TITLE
easier Annotation class input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - you can install a local genome and/or annotation by providing local path(s) to `genomepy install`
     - if annotation downloading is requested, but not annotation path is provided,
     a gtf/gff(3) annotation will be sought in the genome's source directory.
+- `Annotation.gtf_dict` creates a dictionary for any key-value pair in the GTF columns or attribute fields!
+  - e.g. `Annotation.gtf_dict("seqname", "gene_name")`
 
 ### Changed
 - Genome.track2fasta can now ignore comment lines (starting with `#`)
@@ -28,6 +30,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - tweaked search result alignment for clarity
 - explained UCSC annotations in the README
 - better file path handling (relative paths, user home and variables are expanded)
+- `Annotation` now accepts a file/directory/genomepy name as first argument.
+  - this merges 2 arguments into one.
+- `Annotation.map_genes` now works without a README file
+  - you can now set Annotation.tax_id manually.
 
 ### Fixed
 - Ensembl annotations from previous releases can now be downloaded as intended.

--- a/genomepy/annotation/__init__.py
+++ b/genomepy/annotation/__init__.py
@@ -8,12 +8,12 @@ import numpy as np
 import pandas as pd
 from loguru import logger
 
-from genomepy.annotation.mygene import map_genes as _map_genes
-from genomepy.annotation.mygene import query_mygene
-from genomepy.annotation.sanitize import sanitize as _sanitize
+from genomepy.annotation.mygene import _map_genes, query_mygene
+from genomepy.annotation.sanitize import _sanitize
 from genomepy.annotation.utils import _check_property, _parse_annot, read_annot
+from genomepy.files import read_readme
 from genomepy.providers import map_locations
-from genomepy.utils import get_genomes_dir
+from genomepy.utils import cleanpath, get_genomes_dir, safe
 
 __all__ = ["Annotation", "query_mygene", "filter_regex"]
 
@@ -24,11 +24,8 @@ class Annotation:
 
     Parameters
     ----------
-    genome : str
-        Genome name.
-    name : str, optional
-        Name of annotation file.
-        If name is not specified the default annotation for the genome is used.
+    name : str
+        Genome name/directory/fasta or gene annotation BED/GTF file.
     genomes_dir : str, optional
         Genomes installation directory.
 
@@ -55,37 +52,45 @@ class Annotation:
     annotation_contigs: list = None
     "Contigs found in the gene annotation BED"
 
-    def __init__(self, genome: str, name: str = None, genomes_dir: str = None):
-        self.genome = genome
-        self.genome_dir = os.path.join(get_genomes_dir(genomes_dir), genome)
-        if not os.path.exists(self.genome_dir):
-            raise ValueError(f"Genome {self.genome} not found!")
+    def __init__(self, name: str, genomes_dir: str = None):
+        # name and directory
+        n, g = _get_name_and_dir(name, genomes_dir)
+        self.name = n
+        "genome name"
+        self.genome_dir = g
+        "path to the genome directory"
 
-        # annotation file provided
-        if name:
-            suffixes = Path(name).suffixes[-2:]
-            if ".bed" in suffixes or ".BED" in suffixes:
-                self.annotation_bed_file = name
-            elif ".gtf" in suffixes or ".GTF" in suffixes:
-                self.annotation_gtf_file = name
-            else:
-                raise NotImplementedError(
-                    "Only (gzipped) bed and gtf files are supported at the moment!"
-                )
-        else:
-            # annotation files
-            self.annotation_gtf_file = _get_file(
-                self.genome_dir, f"{self.genome}.annotation.gtf"
-            )
-            self.annotation_bed_file = _get_file(
-                self.genome_dir, f"{self.genome}.annotation.bed"
-            )
+        # annotation files
+        fname = cleanpath(name)
+        suffixes = Path(fname).suffixes[-2:]
+        b = fname
+        if not (".bed" in suffixes or ".BED" in suffixes):
+            b = _get_file(self.genome_dir, f"{self.name}.annotation.bed")
+        self.annotation_bed_file = b
+        "path to the gene annotation BED file"
+        g = fname
+        if not (".gtf" in suffixes or ".GTF" in suffixes):
+            g = _get_file(self.genome_dir, f"{self.name}.annotation.gtf")
+        self.annotation_gtf_file = g
+        "path to the gene annotation GTF file"
 
         # genome files
+        g = fname
+        if ".fa" not in suffixes:
+            g = _get_file(self.genome_dir, f"{self.name}.fa", False)
+        self.genome_file = g
+        "path to the genome fasta"
         self.readme_file = _get_file(self.genome_dir, "README.txt", False)
-        self.genome_file = _get_file(self.genome_dir, f"{self.genome}.fa", False)
-        self.index_file = _get_file(self.genome_dir, f"{self.genome}.fa.fai", False)
-        self.sizes_file = _get_file(self.genome_dir, f"{self.genome}.fa.sizes", False)
+        "path to the README file"
+        self.index_file = _get_file(self.genome_dir, f"{self.name}.fa.fai", False)
+        "path to the genome index"
+        self.sizes_file = _get_file(self.genome_dir, f"{self.name}.fa.sizes", False)
+        "path to the chromosome sizes file"
+
+        # genome attributes
+        t = read_readme(str(self.readme_file))[0]["tax_id"]
+        self.tax_id = None if t == "na" else int(t)
+        "genome taxonomy identifier"
 
     # lazy attributes
     def __getattribute__(self, name):
@@ -95,12 +100,12 @@ class Annotation:
 
         # if the attribute is None/empty, check if it is a lazy attribute
         if name == "bed":
-            _check_property(self.annotation_bed_file, f"{self.genome}.annotation.bed")
+            _check_property(self.annotation_bed_file, f"{self.name}.annotation.bed")
             val = read_annot(self.annotation_bed_file)
             setattr(self, name, val)
 
         elif name == "gtf":
-            _check_property(self.annotation_gtf_file, f"{self.genome}.annotation.gtf")
+            _check_property(self.annotation_gtf_file, f"{self.name}.annotation.gtf")
             val = read_annot(self.annotation_gtf_file)
             setattr(self, name, val)
 
@@ -115,7 +120,7 @@ class Annotation:
             setattr(self, name, val)
 
         elif name == "genome_contigs":
-            _check_property(self.sizes_file, f"{self.genome}.fa.sizes")
+            _check_property(self.sizes_file, f"{self.name}.fa.sizes")
             val = list(
                 set(pd.read_csv(self.sizes_file, sep="\t", header=None, dtype=str)[0])
             )
@@ -229,8 +234,12 @@ class Annotation:
         pandas.DataFrame
             chromosome mapping.
         """
+        if self.readme_file is None:
+            raise AttributeError(
+                "Can only map genomepy annotations (a readme file is required)"
+            )
         genomes_dir = os.path.dirname(self.genome_dir)
-        mapping = map_locations(self.genome, to, genomes_dir)
+        mapping = map_locations(self.name, to, genomes_dir)
         if mapping is None:
             return
 
@@ -283,6 +292,33 @@ class Annotation:
         """
         df = _parse_annot(self, annot)
         return filter_regex(df, regex, invert_match, column)
+
+
+def _get_name_and_dir(name, genomes_dir=None):
+    """
+    Returns the name and directory of the genome.
+    """
+    fname = cleanpath(name)
+    genomes_dir = get_genomes_dir(genomes_dir, check_exist=False)
+    if os.path.isfile(fname):
+        exts = ["gtf", "GTF", "bed", "BED", "fa"]
+        if not any(ext in fname for ext in exts):
+            raise NotImplementedError(
+                "Only (gzipped) bed, gtf or fasta files are supported!"
+            )
+        genome_dir = os.path.dirname(fname)
+        name = safe(os.path.basename(fname))
+        # remove suffices
+        any_ext = "(" + ")|(".join(exts) + ")"
+        name = re.sub(fr"(\.annotation)?\.({any_ext})(\.gz)?$", "", name)
+    elif os.path.isdir(fname):
+        genome_dir = fname
+        name = safe(os.path.basename(fname))
+    elif name in os.listdir(genomes_dir):
+        genome_dir = os.path.join(genomes_dir, name)
+    else:
+        raise ValueError(f"Could not find {name}")
+    return name, genome_dir
 
 
 def _get_file(genome_dir: str, fname: str, warn_missing: Optional[bool] = True):

--- a/genomepy/genome/__init__.py
+++ b/genomepy/genome/__init__.py
@@ -46,10 +46,10 @@ class Genome(Fasta):
     "contents of the gaps file: contigs and the number of Ns contained"
 
     def __init__(self, name, genomes_dir=None, *args, **kwargs):
+        self.name = safe(os.path.basename(re.sub(r"\.fa(\.gz)?$", "", name)))
+        "genome name"
         self.genomes_dir = get_genomes_dir(genomes_dir, check_exist=False)
         "path to the genomepy genomes directory"
-        self.name = os.path.basename(re.sub(".fa(.gz)?$", "", safe(name)))
-        "genome name"
         self.filename = self._parse_filename(name)
         super(Genome, self).__init__(self.filename, *args, **kwargs)
 
@@ -74,7 +74,9 @@ class Genome(Fasta):
         # genome attributes
         metadata, _ = read_readme(self.readme_file)
         self.tax_id = metadata["tax_id"]
+        "genome taxonomy identifier"
         self.assembly_accession = metadata["assembly_accession"]
+        "genome assembly accession"
 
     # lazy attributes
     def __getattribute__(self, name):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,7 @@ def annot():
         f.write(
             """chrM\t15307\t16448\tNP_059343.1\t42\t+\t15307\t16448\t0\t1\t1141,\t0,"""
         )
-    yield genomepy.Annotation(genome="regexp", genomes_dir="tests/data")
+    yield genomepy.Annotation("regexp", genomes_dir="tests/data")
 
     teardown("tests/data/regexp/regexp.")
 

--- a/tests/test_13_annotation.py
+++ b/tests/test_13_annotation.py
@@ -10,6 +10,50 @@ import genomepy.utils
 from genomepy.annotation import query_mygene
 
 
+def test__get_name_and_dir():
+    # working inputs
+    t_dicts = [
+        {
+            "name": "GRCz11",
+            "genomes_dir": "tests/data",
+            "expected_name": "GRCz11",
+            "expected_dir": "tests/data/GRCz11",
+        },
+        {
+            "name": "tests/data/GRCz11",
+            "genomes_dir": None,
+            "expected_name": "GRCz11",
+            "expected_dir": "tests/data/GRCz11",
+        },
+        {
+            "name": "tests/data/GRCz11/GRCz11.annotation.bed",
+            "genomes_dir": None,
+            "expected_name": "GRCz11",
+            "expected_dir": "tests/data/GRCz11",
+        },
+        # works with warnings
+        {
+            "name": "empty",
+            "genomes_dir": "tests/data",
+            "expected_name": "empty",
+            "expected_dir": "tests/data/empty",
+        },
+    ]
+    for td in t_dicts:
+        name, genome_dir = genomepy.annotation._get_name_and_dir(
+            td["name"], td["genomes_dir"]
+        )
+        assert name == td["expected_name"], td
+        assert genome_dir == genomepy.utils.cleanpath(td["expected_dir"]), td
+
+    # does not exist
+    with pytest.raises(ValueError):
+        genomepy.annotation._get_name_and_dir("tests/data/GRCz11/GRCz11.annotation.BED")
+    # no bed/gtf/fa
+    with pytest.raises(NotImplementedError):
+        genomepy.annotation._get_name_and_dir("tests/data/GRCz11/README.txt")
+
+
 def test_annotation_init(caplog, annot):
     assert annot.genome_file.endswith("data/regexp/regexp.fa")
     assert annot.annotation_gtf_file.endswith("data/regexp/regexp.annotation.gtf")
@@ -28,19 +72,19 @@ def test_annotation_init(caplog, annot):
     g2 = "tests/data/data.annotation.gtf.gz"
     with genomepy.files._open(g2, "w") as fa:
         fa.write("2")
-    a = genomepy.Annotation(genome="data", genomes_dir="tests")
+    a = genomepy.Annotation("data", genomes_dir="tests")
     assert a.annotation_gtf_file.endswith(g1)
     genomepy.utils.rm_rf(g1)
     genomepy.utils.rm_rf(g2)
 
     # not enough GTF files
-    genomepy.Annotation(genome="empty", genomes_dir="tests/data")
+    genomepy.Annotation("empty", genomes_dir="tests/data")
     assert "Could not find 'empty.annotation.bed" in caplog.text
     assert "Could not find 'empty.annotation.gtf" in caplog.text
 
     # Genome doesn't exist
     with pytest.raises(ValueError):
-        genomepy.Annotation(genome="never_existed", genomes_dir="tests/data")
+        genomepy.Annotation("never_existed", genomes_dir="tests/data")
 
 
 def test_custom_annotation():
@@ -48,25 +92,18 @@ def test_custom_annotation():
         "tests/data/custom.annotation.bed",
         "tests/data/custom.annotation.bed.gz",
     ]:
-        a = genomepy.Annotation(name=fname, genome="sacCer3", genomes_dir="tests/data")
+        a = genomepy.Annotation(name=fname, genomes_dir="tests/data")
         assert a.bed.shape[0] == 10
-
-        with pytest.raises(AttributeError):
-            a.gtf
 
     for fname in [
         "tests/data/custom.annotation.gtf",
         "tests/data/custom.annotation.gtf.gz",
     ]:
-        a = genomepy.Annotation(name=fname, genome="sacCer3", genomes_dir="tests/data")
+        a = genomepy.Annotation(name=fname, genomes_dir="tests/data")
         assert a.gtf.shape[0] == 45
-        with pytest.raises(AttributeError):
-            a.bed
 
     with pytest.raises(NotImplementedError):
-        a = genomepy.Annotation(
-            name="tests/data/regions.txt", genome="sacCer3", genomes_dir="tests/data"
-        )
+        a = genomepy.Annotation(name="tests/data/regions.txt", genomes_dir="tests/data")
 
 
 def test_named_gtf():
@@ -243,13 +280,13 @@ def test__parse_annot():
 def test_match_contigs():
     # nothing to work with
     a = genomepy.Annotation("sacCer3", genomes_dir="tests/data")
-    cd = genomepy.annotation.sanitize.match_contigs(a)
+    cd = genomepy.annotation.sanitize._match_contigs(a)
     assert cd is None
 
     # one missing contig, one fixable contig
     a = genomepy.Annotation("sanitize", genomes_dir="tests/data")
     before = a.gtf
-    cd = genomepy.annotation.sanitize.match_contigs(a)
+    cd = genomepy.annotation.sanitize._match_contigs(a)
     after = a.gtf
 
     assert cd == {"NC_007112.7": "1"}
@@ -268,7 +305,7 @@ def test_filter_contigs():
     a.bed = a.bed.append(row, ignore_index=True)
     assert "chrV" in a.bed.chrom.unique()
 
-    missing_contigs = genomepy.annotation.sanitize.filter_contigs(a)
+    missing_contigs = genomepy.annotation.sanitize._filter_contigs(a)
     assert missing_contigs == {"chrV"}
     assert "chrV" not in a.bed.chrom.unique()
 
@@ -287,7 +324,7 @@ def test_document_sanitizing():
     a = HasReadme()
     cd = {"1": "a", "2": "b"}
     mc = ["1", "2", "3", "4", "5"]
-    genomepy.annotation.sanitize.document_sanitizing(a, cd, mc)
+    genomepy.annotation.sanitize._document_sanitizing(a, cd, mc)
     md, lines = genomepy.files.read_readme(a.readme_file)
     genomepy.utils.rm_rf(a.readme_file)
 
@@ -344,38 +381,38 @@ def test_query_mygene():
 def test_parse_mygene_input():
     # wrong product
     with pytest.raises(ValueError):
-        genomepy.annotation.mygene.parse_mygene_input("", "illegal!")
+        genomepy.annotation.mygene._parse_mygene_input("", "illegal!")
 
     # wrong field
     with pytest.raises(ValueError):
-        genomepy.annotation.mygene.parse_mygene_input("illegal!", None)
+        genomepy.annotation.mygene._parse_mygene_input("illegal!", None)
 
     # correct input
-    gf, p = genomepy.annotation.mygene.parse_mygene_input(
+    gf, p = genomepy.annotation.mygene._parse_mygene_input(
         "refseq.translation.rna", None
     )
     assert gf == "refseq.translation.rna" and p is None
-    gf, p = genomepy.annotation.mygene.parse_mygene_input("NAME", "RNA")
+    gf, p = genomepy.annotation.mygene._parse_mygene_input("NAME", "RNA")
     assert gf == "name" and p == "rna"
 
 
-def test_ensembl_genome_info():
-    # Works
-    a = genomepy.Annotation("sacCer3", genomes_dir="tests/data")
-    egi = genomepy.annotation.mygene.ensembl_genome_info(a)
-    assert egi == ("R64-1-1", "GCA_000146045.2", 4932)
-    # genomepy.utils.rm_rf(os.path.join(a.genome_dir, "assembly_report.txt"))
-
-    # No readme
-    a = genomepy.Annotation("regexp", genomes_dir="tests/data")
-    readme_file = os.path.join(a.genome_dir, "README.txt")
-    with pytest.raises(FileNotFoundError):
-        genomepy.annotation.mygene.ensembl_genome_info(a)
-
-    # Empty readme
-    with open(readme_file, "w") as f:
-        f.write("\n")
-    a = genomepy.Annotation("regexp", genomes_dir="tests/data")
-    egi = genomepy.annotation.mygene.ensembl_genome_info(a)
-    assert egi is None
-    genomepy.utils.rm_rf(readme_file)
+# def test_ensembl_genome_info():
+#     # Works
+#     a = genomepy.Annotation("sacCer3", genomes_dir="tests/data")
+#     egi = genomepy.annotation.mygene.ensembl_genome_info(a)
+#     assert egi == ("R64-1-1", "GCA_000146045.2", 4932)
+#     # genomepy.utils.rm_rf(os.path.join(a.genome_dir, "assembly_report.txt"))
+#
+#     # No readme
+#     a = genomepy.Annotation("regexp", genomes_dir="tests/data")
+#     readme_file = os.path.join(a.genome_dir, "README.txt")
+#     with pytest.raises(FileNotFoundError):
+#         genomepy.annotation.mygene.ensembl_genome_info(a)
+#
+#     # Empty readme
+#     with open(readme_file, "w") as f:
+#         f.write("\n")
+#     a = genomepy.Annotation("regexp", genomes_dir="tests/data")
+#     egi = genomepy.annotation.mygene.ensembl_genome_info(a)
+#     assert egi is None
+#     genomepy.utils.rm_rf(readme_file)

--- a/tests/test_13_annotation.py
+++ b/tests/test_13_annotation.py
@@ -182,6 +182,20 @@ def test_filter_regex():
     genomepy.utils.rm_rf(gtf_file)
 
 
+def test_gtf_dict():
+    a = genomepy.annotation.Annotation("GRCz11", genomes_dir="tests/data")
+    gid2gname = a.gtf_dict("gene_id", "gene_name")
+    assert gid2gname["ENSDARG00000103202"] == "CR383668.1"
+    gid2gname = a.gtf_dict("gene_id", "gene_name", False)
+    assert gid2gname["ENSDARG00000103202"] == ["CR383668.1"]
+
+    seq2tid = a.gtf_dict("seqname", "transcript_id")
+    assert seq2tid["1"] == ["ENSDART00000171868"]
+
+    with pytest.raises(IndexError):
+        a.gtf_dict("gene_name", "transcript_id", annot="bed")
+
+
 # annotation.utils.py
 
 

--- a/tests/test_13_annotation.py
+++ b/tests/test_13_annotation.py
@@ -48,7 +48,7 @@ def test__get_name_and_dir():
 
     # does not exist
     with pytest.raises(ValueError):
-        genomepy.annotation._get_name_and_dir("tests/data/GRCz11/GRCz11.annotation.BED")
+        genomepy.annotation._get_name_and_dir("tests/data/GRCz11/what.who")
     # no bed/gtf/fa
     with pytest.raises(NotImplementedError):
         genomepy.annotation._get_name_and_dir("tests/data/GRCz11/README.txt")

--- a/tests/test_13_annotation.py
+++ b/tests/test_13_annotation.py
@@ -191,9 +191,9 @@ def test_gtf_dict():
 
     seq2tid = a.gtf_dict("seqname", "transcript_id")
     assert seq2tid["1"] == ["ENSDART00000171868"]
-
-    with pytest.raises(IndexError):
-        a.gtf_dict("gene_name", "transcript_id", annot="bed")
+    #
+    # with pytest.raises(IndexError):
+    #     a.gtf_dict("gene_name", "transcript_id", annot="bed")
 
 
 # annotation.utils.py


### PR DESCRIPTION
`genomepy.Annotation` now accepts any of the following inputs:
- a genomepy name, 
- a genome directory, 
- a genome fasta, 
- a gene annotation BED or 
- a gene annotation GTF file.
optional argument `genomes_dir` is only used if the above input isn't a file or directory. 

This reduces the number of input arguments from 3 to 2, and makes it much easier to instantiate the class with a file/genome in a non-default `genomes_dir`ectory.

Secondly, the `Annotation.map_genes` function is no longer dependent on a README file. It does however require a `tax_id`. If no readme is present in the genome directory, a meaningful error is returned informing the user they can set `Annotation.tax_id` themselves.

Thirdly, `Annotation.gtf_dict` can be used to create a dict with any column **or attributes field** as key/value.