### PR TITLE
Lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 - `quiet` flag for `genomepy.Annotation`
 - `genomepy.Annotation.lengths()` to retrieve the gene/transcript lengths.
+- `genomepy.Annotation.from_attributes()` can extract any sub-column that pesky attributes column
 - `genomepy -v` flag
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - `quiet` flag for `genomepy.Annotation`
+- `genomepy.Annotation.lengths()` to retrieve the gene/transcript lengths.
 - `genomepy -v` flag
 
 ### Changed

--- a/genomepy/annotation/__init__.py
+++ b/genomepy/annotation/__init__.py
@@ -140,16 +140,35 @@ class Annotation:
             self.genome_contigs = None  # noqa
         super(Annotation, self).__setattr__(name, value)
 
-    def from_attributes(self, field, annot="gtf", check=True):
-        """Convert the specified GTF attribute field to a pandas series"""
+    def from_attributes(
+        self, field, annot: Union[str, pd.DataFrame] = "gtf", check=True
+    ):
+        """
+        Convert the specified GTF attribute field to a pandas series
+
+        Parameters
+        ----------
+        field : str
+            field from the GTF's attribute column.
+        annot : str or pd.Dataframe, optional
+            any GTF in dataframe format, or the default GTF.
+        check : bool, optional
+            filter the GTF for rows containing field?
+
+        Returns
+        -------
+        pd.Dataframe
+            with the same index as the input GTF and the field column
+        """
         df = _parse_annot(self, annot)
         if check:
-            df = self.gtf[self.gtf["attribute"].str.contains(field)]
+            df = df[df["attribute"].str.contains(field)]
             if len(df) == 0:
                 raise ValueError(f"{field} not in GTF attributes!")
 
         # extract the text between the quotes
         series = df["attribute"].str.extract(fr'{field} "(.*?)"', expand=False)
+        series.name = field
         return series
 
     def genes(self, annot: str = "bed") -> list:

--- a/tests/test_13_annotation.py
+++ b/tests/test_13_annotation.py
@@ -196,6 +196,18 @@ def test_gtf_dict():
     #     a.gtf_dict("gene_name", "transcript_id", annot="bed")
 
 
+def test_lengths():
+    a = genomepy.annotation.Annotation("GRCz11", genomes_dir="tests/data")
+
+    gene_lengths = a.lengths()
+    assert str(gene_lengths["length"].dtype) == "uint32"
+    expected_genes = a.named_gtf[a.named_gtf.feature == "exon"].index.unique()
+    assert sorted(expected_genes) == sorted(gene_lengths.index)
+
+    transcript_lengths = a.lengths(False)
+    assert transcript_lengths.index[0].startswith("ENSDART")
+
+
 # annotation.utils.py
 
 

--- a/tests/test_13_annotation.py
+++ b/tests/test_13_annotation.py
@@ -204,7 +204,7 @@ def test_lengths():
     expected_genes = a.named_gtf[a.named_gtf.feature == "exon"].index.unique()
     assert sorted(expected_genes) == sorted(gene_lengths.index)
 
-    transcript_lengths = a.lengths(False)
+    transcript_lengths = a.lengths(gene_level=False)
     assert transcript_lengths.index[0].startswith("ENSDART")
 
 


### PR DESCRIPTION
I needed gene lengths to convert counts to TPMs, but couldn't find a _simple_ gtf2lengths method.

`genomepy.Annotation.lengths()` returns the gene length per gene, based on the sum of all exons in the longest transcript. The numbers aren't perfect, as gene lengths (and effective lengths) is a rabbit hole, but they are generally very close.

