### PR TITLE
fixed tests

### DIFF
--- a/tests/test_14_functions.py
+++ b/tests/test_14_functions.py
@@ -20,7 +20,7 @@ def test_list_available_genomes():
     g = genomepy.functions.list_available_genomes("Ensembl")
     metadata = next(g)
     assert isinstance(metadata, list)
-    assert metadata[0:2] == ["mCalJac1.pat.X", "Ensembl"]
+    assert metadata[0:2] == ["ASM394721v1", "Ensembl"] 
 
 
 def test_list_installed_genomes():

--- a/tests/test_14_functions.py
+++ b/tests/test_14_functions.py
@@ -20,7 +20,7 @@ def test_list_available_genomes():
     g = genomepy.functions.list_available_genomes("Ensembl")
     metadata = next(g)
     assert isinstance(metadata, list)
-    assert metadata[0:2] == ["ASM394721v1", "Ensembl"] 
+    assert metadata[0:2] == ["ASM394721v1", "Ensembl"]
 
 
 def test_list_installed_genomes():

--- a/tests/test_e01_link_options.py
+++ b/tests/test_e01_link_options.py
@@ -35,7 +35,7 @@ if not skip:
         These genomes are hosted on ftp.ensemblgenomes.org.
         """
         mask = masking if masking != "unmasked" else "none"
-        for genome in ["Amel_HAv3.1", "WBcel235"]:
+        for genome in ["Amel_HAv3.1", "ASM23943v1"]:
             assert ensembl.get_genome_download_link(genome, mask=mask)
 
     def test_ucsc_genome_download_links(masking, ucsc):


### PR DESCRIPTION
Fixed unit tests:
- `tests/test_14_functions.py`:  
 assertion fails due to genome name mismatch at specified index for mCalJac1.pat.X. This should be ASM394721v1

-  Hardcoded name fix for WBcel235 download link
