### PR TITLE
check all URLs per provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - now using `filelock` for improved thread safety
+- now checking if every API/FTP/HTTP(S) is accessible before proceeding
 
 ### Changed
 - switched to `pyproject.toml` + `hatchling` for packaging

--- a/genomepy/providers/ensembl.py
+++ b/genomepy/providers/ensembl.py
@@ -50,7 +50,10 @@ class EnsemblProvider(BaseProvider):
     @staticmethod
     def ping():
         """Can the provider be reached?"""
-        return bool(check_url("https://rest.ensembl.org/info/ping?"))
+        api_online = bool(check_url("https://rest.ensembl.org/info/ping?"))
+        vertebrate_url_online = bool(check_url("http://ftp.ensembl.org"))
+        other_url_online = bool(check_url("http://ftp.ensemblgenomes.org"))
+        return api_online and vertebrate_url_online and other_url_online
 
     def _genome_info_tuple(self, name, size=False):
         """tuple with assembly metadata"""

--- a/genomepy/providers/gencode.py
+++ b/genomepy/providers/gencode.py
@@ -33,12 +33,12 @@ class GencodeProvider(BaseProvider):
         "text_search",
     ]
     _cli_install_options = {}
-    _ftp_link = "ftp://ftp.ebi.ac.uk/pub/databases/gencode"
+    _url = "ftp://ftp.ebi.ac.uk/pub/databases/gencode"
 
     def __init__(self):
         self._provider_status()
         # Populate on init, so that methods can be cached
-        self.genomes = _get_genomes(self._ftp_link)
+        self.genomes = _get_genomes(self._url)
         self.ucsc = UcscProvider()
         self.gencode2ucsc = get_gencode2ucsc(self.genomes)
         self._update_genomes()
@@ -46,7 +46,8 @@ class GencodeProvider(BaseProvider):
     @staticmethod
     def ping():
         """Can the provider be reached?"""
-        return bool(check_url("ftp.ebi.ac.uk/pub/databases/gencode"))
+        ftp_online = bool(check_url("ftp.ebi.ac.uk/pub/databases/gencode"))
+        return ftp_online
 
     def _genome_info_tuple(self, name, size=False):
         """tuple with assembly metadata"""

--- a/genomepy/providers/ncbi.py
+++ b/genomepy/providers/ncbi.py
@@ -56,7 +56,8 @@ class NcbiProvider(BaseProvider):
     @staticmethod
     def ping():
         """Can the provider be reached?"""
-        return bool(check_url("https://ftp.ncbi.nlm.nih.gov/genomes/ASSEMBLY_REPORTS/"))
+        url_online = bool(check_url("https://ftp.ncbi.nlm.nih.gov/genomes/"))
+        return url_online
 
     def _genome_info_tuple(self, name, size=False):
         """tuple with assembly metadata"""

--- a/genomepy/providers/ucsc.py
+++ b/genomepy/providers/ucsc.py
@@ -53,7 +53,9 @@ class UcscProvider(BaseProvider):
     @staticmethod
     def ping():
         """Can the provider be reached?"""
-        return bool(check_url("http://hgdownload.soe.ucsc.edu/goldenPath"))
+        url_online = bool(check_url("http://hgdownload.soe.ucsc.edu/goldenPath"))
+        api_online = bool(check_url("http://api.genome.ucsc.edu/list/ucscGenomes"))
+        return url_online and api_online
 
     def _search_accession(self, term: str) -> Iterator[str]:
         """


### PR DESCRIPTION
Genomepy was only checking one URL per provider. Unfortunately, it seems that providers (atleast UCSC) can have issues with one website/service, while another is still up (see #213). 

This PR will check all URLs used, which should improve feedback to the user. Before merging, I'd like to test it with UCSC back up though, so until then this is a draft.