### PR TITLE
dont fail when disabling an already disabled plugin

### DIFF
--- a/genomepy/plugins/__init__.py
+++ b/genomepy/plugins/__init__.py
@@ -151,10 +151,10 @@ def manage_plugins(command: str, plugin_names: list = None):
             raise ValueError(f"Unknown plugin: '{name}'.")
 
     if command in ["enable", "activate"]:
-        [active_plugins.append(name) for name in plugin_names]
+        [active_plugins.append(name) for name in plugin_names if name in active_plugins]
 
     elif command in ["disable", "deactivate"]:
-        [active_plugins.remove(name) for name in plugin_names]
+        [active_plugins.remove(name) for name in plugin_names if name in active_plugins]
 
     else:
         raise ValueError(

--- a/genomepy/plugins/__init__.py
+++ b/genomepy/plugins/__init__.py
@@ -151,7 +151,7 @@ def manage_plugins(command: str, plugin_names: list = None):
             raise ValueError(f"Unknown plugin: '{name}'.")
 
     if command in ["enable", "activate"]:
-        [active_plugins.append(name) for name in plugin_names if name in active_plugins]
+        [active_plugins.append(name) for name in plugin_names if name not in active_plugins]
 
     elif command in ["disable", "deactivate"]:
         [active_plugins.remove(name) for name in plugin_names if name in active_plugins]


### PR DESCRIPTION
E.g. try to deactivate everything (some plugins are turned off by default):

```
genomepy plugin disable {blacklist,bowtie2,bwa,gmap,hisat2,minimap2,star}
```

This has impact on the snakemake-wrapper. I noticed it fails, because somehow it got updated from an old version to the newest and now it doesnt work :(
https://snakemake-wrappers.readthedocs.io/en/stable/wrappers/genomepy.html