### PR TITLE
Logger

### DIFF
--- a/genomepy/__init__.py
+++ b/genomepy/__init__.py
@@ -54,7 +54,7 @@ __all__ = [
 # sys.tracebacklimit = 0
 
 # logger is a singleton, configuration here will be used module-wide
-logger.remove(0)
+logger.remove()
 logger.add(
     sys.stderr,
     format="<green>{time:HH:mm:ss}</green> <bold>|</bold> <blue>{level}</blue> <bold>|</bold> {message}",

--- a/genomepy/__init__.py
+++ b/genomepy/__init__.py
@@ -54,7 +54,7 @@ __all__ = [
 # sys.tracebacklimit = 0
 
 # logger is a singleton, configuration here will be used module-wide
-logger.remove()
+logger.remove(0)
 logger.add(
     sys.stderr,
     format="<green>{time:HH:mm:ss}</green> <bold>|</bold> <blue>{level}</blue> <bold>|</bold> {message}",

--- a/genomepy/caching.py
+++ b/genomepy/caching.py
@@ -5,6 +5,7 @@ from time import time
 from appdirs import user_cache_dir
 from diskcache import Cache
 from filelock import FileLock
+from loguru import logger
 
 from genomepy.__about__ import __version__
 from genomepy.config import config
@@ -45,4 +46,4 @@ def clean():
     """Remove cached data on providers."""
     rmtree(genomepy_cache_dir, ignore_errors=True)
     os.makedirs(genomepy_cache_dir, exist_ok=True)
-    print("All clean!")
+    logger.info("All clean!")

--- a/genomepy/config/__init__.py
+++ b/genomepy/config/__init__.py
@@ -2,6 +2,7 @@ import os
 from shutil import copyfile
 
 from appdirs import user_config_dir
+from loguru import logger
 from norns import config as cfg
 
 __all__ = ["config", "manage_config"]
@@ -21,7 +22,7 @@ def generate_config():
     default_config = cfg("genomepy", default="config/default.yaml").config_file
     copyfile(default_config, new_config)
     config.config_file = new_config
-    print(f"Created config file {new_config}")
+    logger.info(f"Created config file {new_config}")
 
 
 def manage_config(command):

--- a/genomepy/plugins/hisat2.py
+++ b/genomepy/plugins/hisat2.py
@@ -28,7 +28,6 @@ class Hisat2Plugin(Plugin):
 
             # if an annotation is present, generate a splice-aware index
             gtf_file = genome.annotation_gtf_file
-            print(gtf_file)
             if gtf_file:
                 with extracted_file(gtf_file) as _gtf_file:
                     # generate splice and exon site files to enhance indexing
@@ -60,7 +59,6 @@ class Hisat2Plugin(Plugin):
 
                 # Create index
                 run_index_cmd("hisat2", cmd)
-            print(gtf_file)
 
     def get_properties(self, genome):
         props = {

--- a/tests/test_01_basic.py
+++ b/tests/test_01_basic.py
@@ -87,11 +87,10 @@ def test_config():
     assert len(config.keys()) == 5
 
 
-def test_manage_config(capsys):
+def test_manage_config(caplog, capsys):
     # make a new config
     genomepy.config.manage_config("generate")
-    captured = capsys.readouterr().out.strip()
-    assert captured.startswith("Created config file")
+    assert caplog.text.count("Created config file") == 1
 
     # check where it is found
     fname = os.path.expanduser("~/Library/Application Support/genomepy/genomepy.yaml")
@@ -112,8 +111,7 @@ def test_manage_config(capsys):
 
     # make a new config
     genomepy.config.manage_config("generate")
-    captured = capsys.readouterr().out.strip()
-    assert captured.startswith("Created config file")
+    assert caplog.text.count("Created config file") == 2
 
     # check if the mess was fixed
     genomepy.config.manage_config("show")


### PR DESCRIPTION
Replaced `logger.remove()` with `logger.remove(0)`. This function is needed to prevent [double logging](https://loguru.readthedocs.io/en/stable/resources/recipes.html#avoiding-logs-to-be-printed-twice-on-the-terminal). 0 removes the default handler, None (the default value) removes all handlers.